### PR TITLE
Fix unintended node selection bug and tooltip dismissal bug

### DIFF
--- a/WPFSKillTree/MainWindow.xaml
+++ b/WPFSKillTree/MainWindow.xaml
@@ -43,7 +43,7 @@
                 </StackPanel>
             </Border>
         </Popup>
-        <POESKillTree:ZoomBorder BorderBrush="Silver" BorderThickness="1" Height="auto" x:Name="border1" ClipToBounds="True" MouseMove="border1_MouseMove" Margin="415,12,4,29" Click="border1_Click" Background="Black" FlowDirection="LeftToRight" Grid.Column="3">
+        <POESKillTree:ZoomBorder BorderBrush="Silver" BorderThickness="1" Height="auto" x:Name="border1" ClipToBounds="True" MouseMove="border1_MouseMove" Margin="415,12,4,29" Click="border1_Click" Background="Black" FlowDirection="LeftToRight" Grid.Column="3" MouseLeave="border1_MouseLeave">
             <Rectangle Height="559" x:Name="image1" Stretch="Uniform" Width="749" ClipToBounds="false" Margin="13,17,7,17"/>
         </POESKillTree:ZoomBorder>
         <Label x:Name="lblSkillURL" Content="Build link:" HorizontalAlignment="Left" Margin="122,0,0,1" VerticalAlignment="Bottom" Grid.Column="3"/>

--- a/WPFSKillTree/MainWindow.xaml.cs
+++ b/WPFSKillTree/MainWindow.xaml.cs
@@ -743,6 +743,14 @@ namespace POESKillTree
             sToolTip.IsOpen = false;
 
         }
+
+        private void border1_MouseLeave(object sender, MouseEventArgs e)
+        {
+            // We might have popped up a tooltip while the window didn't have focus,
+            // so we should close tooltips whenever the mouse leaves the canvas in addition to
+            // whenever we lose focus.
+            sToolTip.IsOpen = false;
+        }
     }
 
     class PoEBuild

--- a/WPFSKillTree/ZoomBorder.cs
+++ b/WPFSKillTree/ZoomBorder.cs
@@ -185,10 +185,20 @@ namespace POESKillTree
 
         private void child_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
+            // Not sure if this takes the zoom factor into account, but this feels reasonable.
+            const double dragThreshold = 5;
+
             if (child != null)
             {
                 child.ReleaseMouseCapture();
                 this.Cursor = Cursors.Arrow;
+
+                if ((start - e.GetPosition(this)).LengthSquared >= dragThreshold * dragThreshold)
+                {
+                    // If we dragged a distance larger than our threshold, handle the up event so that
+                    // it's not treated as a click on a skill node.
+                    e.Handled = true;
+                }
             }
         }
 


### PR DESCRIPTION
This fixes two bugs:
- Unintended skill selection while panning -- The problem here is that
  if you click on a node and then drag, the mouse up event causes the drag
  to end but it also causes the node to get selected.  The fix is to mark
  the up event as handled if we dragged a meaningful distance; this
  prevents the up event from also selecting the node.  This bug gets hit
  all the time when I watch streamers and is the common root cause for
  "Hey why did you select node XYZ?" "Oh whoops, I don't know how that
  happened"
- Tooltips don't get dismissed sometimes -- If you have another window
  open over the planner and then mouse over a node, a tooltip will pop up.
  If you do it fast enough such that you just briefly move over a node
  before your mouse ends up in another window, you can end up with a
  tooltip that never goes away.  The fix here is to dismiss the tooltip
  whenever the mouse leaves the canvas.
