### PR TITLE
Fixed crash with item having gem support modifier for gem not in DB.

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/ItemDB.cs
+++ b/WPFSKillTree/SkillTreeFiles/ItemDB.cs
@@ -1187,6 +1187,9 @@ namespace POESKillTree.SkillTreeFiles
         // Returns attributes of gem at specified level and quality.
         public static AttributeSet AttributesOf(string gemName, int level, int quality)
         {
+            if (!GemIndex.ContainsKey(gemName))
+                return new AttributeSet();
+
             Gem gem = GemIndex[gemName];
 
             // Get level-based attributes.


### PR DESCRIPTION
Fixes issue #5 reported in other repo.
