### PR TITLE
Basic Tree comparison

### DIFF
--- a/WPFSKillTree/Model/Options.cs
+++ b/WPFSKillTree/Model/Options.cs
@@ -1,11 +1,36 @@
-﻿namespace POESKillTree.Model
+﻿using System.ComponentModel;
+namespace POESKillTree.Model
 {
-    public class Options
+    public class Options : INotifyPropertyChanged
     {
         public string Theme { get; set; }
         public string Accent { get; set; } //Controlled by Menu Accent Headers
-        public bool AttributesBarOpened  { get; set; }
+        public bool AttributesBarOpened { get; set; }
         public bool BuildsBarOpened { get; set; }
+
+
+        private bool _TreeComparisonEnabled = false;
+        public bool TreeComparisonEnabled
+        {
+            get { return _TreeComparisonEnabled; }
+            set
+            {
+                _TreeComparisonEnabled = value;
+                OnPropertyChanged("TreeComparisonEnabled");
+            }
+        }
+
+        private int _SelectedBuildIndex = -1;
+
+        public int SelectedBuildIndex
+        {
+            get { return _SelectedBuildIndex; }
+            set 
+            { 
+                _SelectedBuildIndex = value;
+                OnPropertyChanged("SelectedBuildIndex");
+            }
+        }
 
         public Options()
         {
@@ -14,5 +39,13 @@
             AttributesBarOpened = false;
             BuildsBarOpened = false;
         }
+
+        private void OnPropertyChanged(string caller)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(caller));
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 }

--- a/WPFSKillTree/Model/PersistentData.cs
+++ b/WPFSKillTree/Model/PersistentData.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Windows.Controls;
 using System.Xml.Serialization;
 using POESKillTree.ViewModels;
+using System.ComponentModel;
 
 namespace POESKillTree.Model
 {
-    public class PersistentData
+    public class PersistentData : INotifyPropertyChanged
     {
         public Options Options { get; set; }
         public PoEBuild CurrentBuild { get; set; }
@@ -43,6 +44,7 @@ namespace POESKillTree.Model
                 Builds = obj.Builds;
                 CurrentBuild = obj.CurrentBuild;
                 reader.Close();
+                OnPropertyChanged(null);
             }
         }
 
@@ -51,5 +53,13 @@ namespace POESKillTree.Model
             Builds = (from PoEBuild item in items select item).ToList();
             SavePersistentDataToFile();
         }
+
+        private void OnPropertyChanged(string caller)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(caller));
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 }

--- a/WPFSKillTree/SkillTreeFiles/Compute.cs
+++ b/WPFSKillTree/SkillTreeFiles/Compute.cs
@@ -2270,7 +2270,7 @@ namespace POESKillTree.SkillTreeFiles
             IsWieldingShield = MainHand.Is(WeaponType.Shield) || OffHand.Is(WeaponType.Shield);
             IsWieldingStaff = MainHand.Is(WeaponType.Staff);
 
-            Level = skillTree._level;
+            Level = skillTree.Level;
             if (Level < 1) Level = 1;
             else if (Level > 100) Level = 100;
 
@@ -2310,7 +2310,7 @@ namespace POESKillTree.SkillTreeFiles
 
             CoreAttributes();
 
-            Implicit = new AttributeSet(SkillTree.ImplicitAttributes(Global, skillTree.Level));
+            Implicit = new AttributeSet(SkillTree.ImplicitAttributes(Global, Level));
             Global.Add(Implicit);
 
             // Innate dual wielding bonuses.

--- a/WPFSKillTree/SkillTreeFiles/Compute.cs
+++ b/WPFSKillTree/SkillTreeFiles/Compute.cs
@@ -2310,7 +2310,7 @@ namespace POESKillTree.SkillTreeFiles
 
             CoreAttributes();
 
-            Implicit = new AttributeSet(skillTree.ImplicitAttributes(Global));
+            Implicit = new AttributeSet(SkillTree.ImplicitAttributes(Global, skillTree.Level));
             Global.Add(Implicit);
 
             // Innate dual wielding bonuses.

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -618,5 +618,10 @@ namespace POESKillTree.SkillTreeFiles
             picSkillSurroundHighlight = new DrawingVisual();
             picPathHighlight = new DrawingVisual();
         }
+
+        public static void ClearAssets()
+        {
+            _Initialized = false;
+        }
     }
 }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -13,16 +13,35 @@ namespace POESKillTree.SkillTreeFiles
     {
         #region Members
 
-        public List<KeyValuePair<Rect, ImageBrush>> FacesBrush = new List<KeyValuePair<Rect, ImageBrush>>();
-        public List<KeyValuePair<Size, ImageBrush>> NodeSurroundBrush = new List<KeyValuePair<Size, ImageBrush>>();
+        private static List<KeyValuePair<Rect, ImageBrush>> _FacesBrush = new List<KeyValuePair<Rect, ImageBrush>>();
 
-        public List<KeyValuePair<Size, ImageBrush>> NodeSurroundHighlightBrush = new List<KeyValuePair<Size, ImageBrush>>();
+        public static List<KeyValuePair<Rect, ImageBrush>> FacesBrush
+        {
+            get { return _FacesBrush; }
+        }
+
+        private static List<KeyValuePair<Size, ImageBrush>> _NodeSurroundBrush = new List<KeyValuePair<Size, ImageBrush>>();
+
+        public static List<KeyValuePair<Size, ImageBrush>> NodeSurroundBrush
+        {
+            get { return SkillTree._NodeSurroundBrush; }
+        }
+
+        private List<KeyValuePair<Size, ImageBrush>> _NodeSurroundHighlightBrush = new List<KeyValuePair<Size, ImageBrush>>();
+
+        public List<KeyValuePair<Size, ImageBrush>> NodeSurroundHighlightBrush
+        {
+            get { return _NodeSurroundHighlightBrush; }
+        }
+
+        private static Dictionary<bool, KeyValuePair<Rect, ImageBrush>> _StartBackgrounds = new Dictionary<bool, KeyValuePair<Rect, ImageBrush>>();
+
+        public static Dictionary<bool, KeyValuePair<Rect, ImageBrush>> StartBackgrounds
+        {
+            get { return SkillTree._StartBackgrounds; }
+        }
 
         public DrawingVisual SkillTreeVisual;
-
-        public Dictionary<bool, KeyValuePair<Rect, ImageBrush>> StartBackgrounds =
-            new Dictionary<bool, KeyValuePair<Rect, ImageBrush>>();
-
         public DrawingVisual picActiveLinks;
         public DrawingVisual picBackground;
         public DrawingVisual picFaces;
@@ -42,13 +61,13 @@ namespace POESKillTree.SkillTreeFiles
         {
             SkillTreeVisual = new DrawingVisual();
             SkillTreeVisual.Children.Add(picBackground);
-            SkillTreeVisual.Children.Add(picPathHighlight);//
+            SkillTreeVisual.Children.Add(picPathHighlight);
             SkillTreeVisual.Children.Add(picLinks);
             SkillTreeVisual.Children.Add(picActiveLinks);
             SkillTreeVisual.Children.Add(picPathOverlay);
             SkillTreeVisual.Children.Add(picSkillIconLayer);
             SkillTreeVisual.Children.Add(picActiveSkillIconLayer);
-            SkillTreeVisual.Children.Add(picSkillSurroundHighlight);//
+            SkillTreeVisual.Children.Add(picSkillSurroundHighlight);
             SkillTreeVisual.Children.Add(picSkillBaseSurround);
             SkillTreeVisual.Children.Add(picSkillSurround);
             SkillTreeVisual.Children.Add(picFaces);
@@ -293,7 +312,7 @@ namespace POESKillTree.SkillTreeFiles
                 }
             }
 
-            var pen2 = new Pen(Brushes.Lime, 20*factor);
+            var pen2 = new Pen(Brushes.Lime, 20 * factor);
             using (DrawingContext dc = picPathHighlight.RenderOpen())
             {
                 foreach (ushort n1 in HighlightedNodes)
@@ -356,7 +375,7 @@ namespace POESKillTree.SkillTreeFiles
                     Vector2D pos = (Skillnodes[skillNode].Position);
 
                     if (Skillnodes[skillNode].IsNotable)
-                    { 
+                    {
                         dc.DrawRectangle(NodeSurroundBrush[5].Value, null,
                             new Rect((int)pos.X - NodeSurroundBrush[5].Key.Width,
                                 (int)pos.Y - NodeSurroundBrush[5].Key.Height,
@@ -484,18 +503,23 @@ namespace POESKillTree.SkillTreeFiles
 
         private void InitFaceBrushesAndLayer()
         {
-            foreach (string faceName in FaceNames)
+            picFaces = new DrawingVisual();
+
+            if (!_Initialized)
             {
-                var bi = ImageHelper.OnLoadBitmapImage(new Uri("Data\\Assets\\" + faceName + ".png", UriKind.Relative));
-                FacesBrush.Add(new KeyValuePair<Rect, ImageBrush>(new Rect(0, 0, bi.PixelWidth, bi.PixelHeight),
-                    new ImageBrush(bi)));
+                foreach (string faceName in FaceNames)
+                {
+                    var bi = ImageHelper.OnLoadBitmapImage(new Uri("Data\\Assets\\" + faceName + ".png", UriKind.Relative));
+                    _FacesBrush.Add(new KeyValuePair<Rect, ImageBrush>(new Rect(0, 0, bi.PixelWidth, bi.PixelHeight),
+                        new ImageBrush(bi)));
+                }
+
+                var bi2 = ImageHelper.OnLoadBitmapImage(new Uri("Data\\Assets\\PSStartNodeBackgroundInactive.png", UriKind.Relative));
+                _StartBackgrounds.Add(false,
+                    (new KeyValuePair<Rect, ImageBrush>(new Rect(0, 0, bi2.PixelWidth, bi2.PixelHeight),
+                        new ImageBrush(bi2))));
             }
 
-            var bi2 = ImageHelper.OnLoadBitmapImage(new Uri("Data\\Assets\\PSStartNodeBackgroundInactive.png", UriKind.Relative));
-            StartBackgrounds.Add(false,
-                (new KeyValuePair<Rect, ImageBrush>(new Rect(0, 0, bi2.PixelWidth, bi2.PixelHeight),
-                    new ImageBrush(bi2))));
-            picFaces = new DrawingVisual();
         }
 
         private void InitNodeSurround()
@@ -503,82 +527,85 @@ namespace POESKillTree.SkillTreeFiles
             picSkillSurround = new DrawingVisual();
             picSkillBaseSurround = new DrawingVisual();
 
-            Size sizeNot;
-            var brNot = new ImageBrush();
-            brNot.Stretch = Stretch.Uniform;
-            BitmapImage PImageNot = _assets[NodeBackgrounds["notable"]].PImage;
-            brNot.ImageSource = PImageNot;
-            sizeNot = new Size(PImageNot.PixelWidth, PImageNot.PixelHeight);
-
-
-            var brKS = new ImageBrush();
-            brKS.Stretch = Stretch.Uniform;
-            BitmapImage PImageKr = _assets[NodeBackgrounds["keystone"]].PImage;
-            brKS.ImageSource = PImageKr;
-            Size sizeKs = new Size(PImageKr.PixelWidth, PImageKr.PixelHeight);
-
-            var brNotH = new ImageBrush();
-            brNotH.Stretch = Stretch.Uniform;
-            BitmapImage PImageNotH = _assets[NodeBackgroundsActive["notable"]].PImage;
-            brNotH.ImageSource = PImageNotH;
-            Size sizeNotH = new Size(PImageNotH.PixelWidth, PImageNotH.PixelHeight);
-
-
-            var brKSH = new ImageBrush();
-            brKSH.Stretch = Stretch.Uniform;
-            BitmapImage PImageKrH = _assets[NodeBackgroundsActive["keystone"]].PImage;
-            brKSH.ImageSource = PImageKrH;
-            Size sizeKsH = new Size(PImageKrH.PixelWidth, PImageKrH.PixelHeight);
-
-            var brNorm = new ImageBrush();
-            brNorm.Stretch = Stretch.Uniform;
-            BitmapImage PImageNorm = _assets[NodeBackgrounds["normal"]].PImage;
-            brNorm.ImageSource = PImageNorm;
-            Size isizeNorm = new Size(PImageNorm.PixelWidth, PImageNorm.PixelHeight);
-
-            var brNormA = new ImageBrush();
-            brNormA.Stretch = Stretch.Uniform;
-            BitmapImage PImageNormA = _assets[NodeBackgroundsActive["normal"]].PImage;
-            brNormA.ImageSource = PImageNormA;
-            Size isizeNormA = new Size(PImageNormA.PixelWidth, PImageNormA.PixelHeight);
-
-            NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(isizeNorm, brNorm));
-            NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(isizeNormA, brNormA));
-            NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeKs, brKS));
-            NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeNot, brNot));
-            NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeKsH, brKSH));
-            NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeNotH, brNotH));
-
-
-
-
-            //outline generator
-            foreach (var item in NodeSurroundBrush)
+            if (!_Initialized)
             {
-                var outlinecolor = Colors.Lime;
-                uint omask = (uint)outlinecolor.B | (uint)outlinecolor.G << 8 | (uint)outlinecolor.R << 16;
+                Size sizeNot;
+                var brNot = new ImageBrush();
+                brNot.Stretch = Stretch.Uniform;
+                BitmapImage PImageNot = _assets[NodeBackgrounds["notable"]].PImage;
+                brNot.ImageSource = PImageNot;
+                sizeNot = new Size(PImageNot.PixelWidth, PImageNot.PixelHeight);
 
-                var bitmap = (BitmapImage)item.Value.ImageSource;
-                var wb = new WriteableBitmap(bitmap.PixelWidth,bitmap.PixelHeight,bitmap.DpiX, bitmap.DpiY,PixelFormats.Bgra32,null);
-                if (wb.Format == PixelFormats.Bgra32)//BGRA is byte order .. little endian in uint reverse it
+
+                var brKS = new ImageBrush();
+                brKS.Stretch = Stretch.Uniform;
+                BitmapImage PImageKr = _assets[NodeBackgrounds["keystone"]].PImage;
+                brKS.ImageSource = PImageKr;
+                Size sizeKs = new Size(PImageKr.PixelWidth, PImageKr.PixelHeight);
+
+                var brNotH = new ImageBrush();
+                brNotH.Stretch = Stretch.Uniform;
+                BitmapImage PImageNotH = _assets[NodeBackgroundsActive["notable"]].PImage;
+                brNotH.ImageSource = PImageNotH;
+                Size sizeNotH = new Size(PImageNotH.PixelWidth, PImageNotH.PixelHeight);
+
+
+                var brKSH = new ImageBrush();
+                brKSH.Stretch = Stretch.Uniform;
+                BitmapImage PImageKrH = _assets[NodeBackgroundsActive["keystone"]].PImage;
+                brKSH.ImageSource = PImageKrH;
+                Size sizeKsH = new Size(PImageKrH.PixelWidth, PImageKrH.PixelHeight);
+
+                var brNorm = new ImageBrush();
+                brNorm.Stretch = Stretch.Uniform;
+                BitmapImage PImageNorm = _assets[NodeBackgrounds["normal"]].PImage;
+                brNorm.ImageSource = PImageNorm;
+                Size isizeNorm = new Size(PImageNorm.PixelWidth, PImageNorm.PixelHeight);
+
+                var brNormA = new ImageBrush();
+                brNormA.Stretch = Stretch.Uniform;
+                BitmapImage PImageNormA = _assets[NodeBackgroundsActive["normal"]].PImage;
+                brNormA.ImageSource = PImageNormA;
+                Size isizeNormA = new Size(PImageNormA.PixelWidth, PImageNormA.PixelHeight);
+
+                NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(isizeNorm, brNorm));
+                NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(isizeNormA, brNormA));
+                NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeKs, brKS));
+                NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeNot, brNot));
+                NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeKsH, brKSH));
+                NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeNotH, brNotH));
+
+
+
+
+                //outline generator
+                foreach (var item in NodeSurroundBrush)
                 {
-                    uint[] pixeldata = new uint[wb.PixelHeight * wb.PixelWidth];
-                    bitmap.CopyPixels(pixeldata, wb.PixelWidth * 4, 0);
-                    for (int i = 0; i < pixeldata.Length; i++)
+                    var outlinecolor = Colors.Lime;
+                    uint omask = (uint)outlinecolor.B | (uint)outlinecolor.G << 8 | (uint)outlinecolor.R << 16;
+
+                    var bitmap = (BitmapImage)item.Value.ImageSource;
+                    var wb = new WriteableBitmap(bitmap.PixelWidth, bitmap.PixelHeight, bitmap.DpiX, bitmap.DpiY, PixelFormats.Bgra32, null);
+                    if (wb.Format == PixelFormats.Bgra32)//BGRA is byte order .. little endian in uint reverse it
                     {
-                        pixeldata[i] = pixeldata[i] & 0xFF000000 | omask;
+                        uint[] pixeldata = new uint[wb.PixelHeight * wb.PixelWidth];
+                        bitmap.CopyPixels(pixeldata, wb.PixelWidth * 4, 0);
+                        for (int i = 0; i < pixeldata.Length; i++)
+                        {
+                            pixeldata[i] = pixeldata[i] & 0xFF000000 | omask;
+                        }
+                        wb.WritePixels(new Int32Rect(0, 0, wb.PixelWidth, wb.PixelHeight), pixeldata, wb.PixelWidth * 4, 0);
+
+                        var ibr = new ImageBrush();
+                        ibr.Stretch = Stretch.Uniform;
+                        ibr.ImageSource = wb;
+
+                        NodeSurroundHighlightBrush.Add(new KeyValuePair<Size, ImageBrush>(item.Key, ibr));
                     }
-                    wb.WritePixels(new Int32Rect(0, 0, wb.PixelWidth, wb.PixelHeight), pixeldata, wb.PixelWidth * 4, 0);
-
-                    var ibr = new ImageBrush();
-                    ibr.Stretch = Stretch.Uniform;
-                    ibr.ImageSource = wb;
-
-                    NodeSurroundHighlightBrush.Add(new KeyValuePair<Size, ImageBrush>(item.Key, ibr));
-                }
-                else
-                {
-                    //throw??
+                    else
+                    {
+                        //throw??
+                    }
                 }
             }
         }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -15,6 +15,9 @@ namespace POESKillTree.SkillTreeFiles
 
         public List<KeyValuePair<Rect, ImageBrush>> FacesBrush = new List<KeyValuePair<Rect, ImageBrush>>();
         public List<KeyValuePair<Size, ImageBrush>> NodeSurroundBrush = new List<KeyValuePair<Size, ImageBrush>>();
+
+        public List<KeyValuePair<Size, ImageBrush>> NodeSurroundHighlightBrush = new List<KeyValuePair<Size, ImageBrush>>();
+
         public DrawingVisual SkillTreeVisual;
 
         public Dictionary<bool, KeyValuePair<Rect, ImageBrush>> StartBackgrounds =
@@ -31,15 +34,21 @@ namespace POESKillTree.SkillTreeFiles
         public DrawingVisual picActiveSkillIconLayer;
         public DrawingVisual picSkillSurround;
 
+
+        public DrawingVisual picSkillSurroundHighlight;
+        public DrawingVisual picPathHighlight;
+
         public void CreateCombineVisual()
         {
             SkillTreeVisual = new DrawingVisual();
             SkillTreeVisual.Children.Add(picBackground);
+            SkillTreeVisual.Children.Add(picPathHighlight);//
             SkillTreeVisual.Children.Add(picLinks);
             SkillTreeVisual.Children.Add(picActiveLinks);
             SkillTreeVisual.Children.Add(picPathOverlay);
             SkillTreeVisual.Children.Add(picSkillIconLayer);
             SkillTreeVisual.Children.Add(picActiveSkillIconLayer);
+            SkillTreeVisual.Children.Add(picSkillSurroundHighlight);//
             SkillTreeVisual.Children.Add(picSkillBaseSurround);
             SkillTreeVisual.Children.Add(picSkillSurround);
             SkillTreeVisual.Children.Add(picFaces);
@@ -73,8 +82,8 @@ namespace POESKillTree.SkillTreeFiles
 
                 var backgroundBrush = new ImageBrush(_assets["Background1"].PImage);
                 backgroundBrush.TileMode = TileMode.Tile;
-                backgroundBrush.Viewport = new Rect(0, 0, 
-                    6 * backgroundBrush.ImageSource.Width / TRect.Width, 
+                backgroundBrush.Viewport = new Rect(0, 0,
+                    6 * backgroundBrush.ImageSource.Width / TRect.Width,
                     6 * backgroundBrush.ImageSource.Height / TRect.Width);
                 drawingContext.DrawRectangle(backgroundBrush, null, TRect);
 
@@ -245,6 +254,61 @@ namespace POESKillTree.SkillTreeFiles
             }
         }
 
+
+        internal void DrawNodeBaseSurroundHighlight()
+        {
+            float factor = 1.2f;
+            using (DrawingContext dc = picSkillSurroundHighlight.RenderOpen())
+            {
+                foreach (ushort skillNode in HighlightedNodes)
+                {
+                    Vector2D pos = (Skillnodes[skillNode].Position);
+
+                    if (Skillnodes[skillNode].IsNotable)
+                    {
+                        dc.DrawRectangle(NodeSurroundHighlightBrush[3].Value, null,
+                            new Rect((int)pos.X - NodeSurroundBrush[3].Key.Width * factor,
+                                (int)pos.Y - NodeSurroundBrush[3].Key.Height * factor,
+                                NodeSurroundBrush[3].Key.Width * 2 * factor,
+                                NodeSurroundBrush[3].Key.Height * 2 * factor));
+                    }
+                    else if (Skillnodes[skillNode].IsKeyStone)
+                    {
+                        dc.DrawRectangle(NodeSurroundHighlightBrush[2].Value, null,
+                            new Rect((int)pos.X - NodeSurroundBrush[2].Key.Width * factor,
+                                (int)pos.Y - NodeSurroundBrush[2].Key.Height * factor,
+                                NodeSurroundBrush[2].Key.Width * 2 * factor,
+                                NodeSurroundBrush[2].Key.Height * 2 * factor));
+                    }
+                    else if (Skillnodes[skillNode].IsMastery)
+                    {
+                        //Needs to be here so that "Masteries" (Middle images of nodes) don't get anything drawn around them.
+                    }
+                    else
+                        dc.DrawRectangle(NodeSurroundHighlightBrush[0].Value, null,
+                            new Rect((int)pos.X - NodeSurroundBrush[0].Key.Width * factor,
+                                (int)pos.Y - NodeSurroundBrush[0].Key.Height * factor,
+                                NodeSurroundBrush[0].Key.Width * 2 * factor,
+                                NodeSurroundBrush[0].Key.Height * 2 * factor));
+                }
+            }
+
+            var pen2 = new Pen(Brushes.Lime, 20*factor);
+            using (DrawingContext dc = picPathHighlight.RenderOpen())
+            {
+                foreach (ushort n1 in HighlightedNodes)
+                {
+                    foreach (SkillNode n2 in Skillnodes[n1].Neighbor)
+                    {
+                        if (HighlightedNodes.Contains(n2.Id))
+                        {
+                            DrawConnection(dc, pen2, n2, Skillnodes[n1]);
+                        }
+                    }
+                }
+            }
+        }
+
         private void DrawNodeBaseSurround()
         {
             using (DrawingContext dc = picSkillBaseSurround.RenderOpen())
@@ -292,7 +356,7 @@ namespace POESKillTree.SkillTreeFiles
                     Vector2D pos = (Skillnodes[skillNode].Position);
 
                     if (Skillnodes[skillNode].IsNotable)
-                    {
+                    { 
                         dc.DrawRectangle(NodeSurroundBrush[5].Value, null,
                             new Rect((int)pos.X - NodeSurroundBrush[5].Key.Width,
                                 (int)pos.Y - NodeSurroundBrush[5].Key.Height,
@@ -438,6 +502,7 @@ namespace POESKillTree.SkillTreeFiles
         {
             picSkillSurround = new DrawingVisual();
             picSkillBaseSurround = new DrawingVisual();
+
             Size sizeNot;
             var brNot = new ImageBrush();
             brNot.Stretch = Stretch.Uniform;
@@ -483,6 +548,39 @@ namespace POESKillTree.SkillTreeFiles
             NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeNot, brNot));
             NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeKsH, brKSH));
             NodeSurroundBrush.Add(new KeyValuePair<Size, ImageBrush>(sizeNotH, brNotH));
+
+
+
+
+            //outline generator
+            foreach (var item in NodeSurroundBrush)
+            {
+                var outlinecolor = Colors.Lime;
+                uint omask = (uint)outlinecolor.B | (uint)outlinecolor.G << 8 | (uint)outlinecolor.R << 16;
+
+                var bitmap = (BitmapImage)item.Value.ImageSource;
+                var wb = new WriteableBitmap(bitmap.PixelWidth,bitmap.PixelHeight,bitmap.DpiX, bitmap.DpiY,PixelFormats.Bgra32,null);
+                if (wb.Format == PixelFormats.Bgra32)//BGRA is byte order .. little endian in uint reverse it
+                {
+                    uint[] pixeldata = new uint[wb.PixelHeight * wb.PixelWidth];
+                    bitmap.CopyPixels(pixeldata, wb.PixelWidth * 4, 0);
+                    for (int i = 0; i < pixeldata.Length; i++)
+                    {
+                        pixeldata[i] = pixeldata[i] & 0xFF000000 | omask;
+                    }
+                    wb.WritePixels(new Int32Rect(0, 0, wb.PixelWidth, wb.PixelHeight), pixeldata, wb.PixelWidth * 4, 0);
+
+                    var ibr = new ImageBrush();
+                    ibr.Stretch = Stretch.Uniform;
+                    ibr.ImageSource = wb;
+
+                    NodeSurroundHighlightBrush.Add(new KeyValuePair<Size, ImageBrush>(item.Key, ibr));
+                }
+                else
+                {
+                    //throw??
+                }
+            }
         }
 
         private void InitOtherDynamicLayers()
@@ -490,6 +588,8 @@ namespace POESKillTree.SkillTreeFiles
             picActiveLinks = new DrawingVisual();
             picPathOverlay = new DrawingVisual();
             picHighlights = new DrawingVisual();
+            picSkillSurroundHighlight = new DrawingVisual();
+            picPathHighlight = new DrawingVisual();
         }
     }
 }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -279,49 +279,56 @@ namespace POESKillTree.SkillTreeFiles
             float factor = 1.2f;
             using (DrawingContext dc = picSkillSurroundHighlight.RenderOpen())
             {
-                foreach (ushort skillNode in HighlightedNodes)
+                if (HighlightedNodes != null)
                 {
-                    Vector2D pos = (Skillnodes[skillNode].Position);
+                    foreach (ushort skillNode in HighlightedNodes)
+                    {
+                        Vector2D pos = (Skillnodes[skillNode].Position);
 
-                    if (Skillnodes[skillNode].IsNotable)
-                    {
-                        dc.DrawRectangle(NodeSurroundHighlightBrush[3].Value, null,
-                            new Rect((int)pos.X - NodeSurroundBrush[3].Key.Width * factor,
-                                (int)pos.Y - NodeSurroundBrush[3].Key.Height * factor,
-                                NodeSurroundBrush[3].Key.Width * 2 * factor,
-                                NodeSurroundBrush[3].Key.Height * 2 * factor));
+                        if (Skillnodes[skillNode].IsNotable)
+                        {
+                            dc.DrawRectangle(NodeSurroundHighlightBrush[3].Value, null,
+                                new Rect((int)pos.X - NodeSurroundBrush[3].Key.Width * factor,
+                                    (int)pos.Y - NodeSurroundBrush[3].Key.Height * factor,
+                                    NodeSurroundBrush[3].Key.Width * 2 * factor,
+                                    NodeSurroundBrush[3].Key.Height * 2 * factor));
+                        }
+                        else if (Skillnodes[skillNode].IsKeyStone)
+                        {
+                            dc.DrawRectangle(NodeSurroundHighlightBrush[2].Value, null,
+                                new Rect((int)pos.X - NodeSurroundBrush[2].Key.Width * factor,
+                                    (int)pos.Y - NodeSurroundBrush[2].Key.Height * factor,
+                                    NodeSurroundBrush[2].Key.Width * 2 * factor,
+                                    NodeSurroundBrush[2].Key.Height * 2 * factor));
+                        }
+                        else if (Skillnodes[skillNode].IsMastery)
+                        {
+                            //Needs to be here so that "Masteries" (Middle images of nodes) don't get anything drawn around them.
+                        }
+                        else
+                            dc.DrawRectangle(NodeSurroundHighlightBrush[0].Value, null,
+                                new Rect((int)pos.X - NodeSurroundBrush[0].Key.Width * factor,
+                                    (int)pos.Y - NodeSurroundBrush[0].Key.Height * factor,
+                                    NodeSurroundBrush[0].Key.Width * 2 * factor,
+                                    NodeSurroundBrush[0].Key.Height * 2 * factor));
                     }
-                    else if (Skillnodes[skillNode].IsKeyStone)
-                    {
-                        dc.DrawRectangle(NodeSurroundHighlightBrush[2].Value, null,
-                            new Rect((int)pos.X - NodeSurroundBrush[2].Key.Width * factor,
-                                (int)pos.Y - NodeSurroundBrush[2].Key.Height * factor,
-                                NodeSurroundBrush[2].Key.Width * 2 * factor,
-                                NodeSurroundBrush[2].Key.Height * 2 * factor));
-                    }
-                    else if (Skillnodes[skillNode].IsMastery)
-                    {
-                        //Needs to be here so that "Masteries" (Middle images of nodes) don't get anything drawn around them.
-                    }
-                    else
-                        dc.DrawRectangle(NodeSurroundHighlightBrush[0].Value, null,
-                            new Rect((int)pos.X - NodeSurroundBrush[0].Key.Width * factor,
-                                (int)pos.Y - NodeSurroundBrush[0].Key.Height * factor,
-                                NodeSurroundBrush[0].Key.Width * 2 * factor,
-                                NodeSurroundBrush[0].Key.Height * 2 * factor));
                 }
             }
 
             var pen2 = new Pen(Brushes.Lime, 20 * factor);
             using (DrawingContext dc = picPathHighlight.RenderOpen())
             {
-                foreach (ushort n1 in HighlightedNodes)
+                if (HighlightedNodes != null)
                 {
-                    foreach (SkillNode n2 in Skillnodes[n1].Neighbor)
+                    foreach (ushort n1 in HighlightedNodes)
                     {
-                        if (HighlightedNodes.Contains(n2.Id))
+
+                        foreach (SkillNode n2 in Skillnodes[n1].Neighbor)
                         {
-                            DrawConnection(dc, pen2, n2, Skillnodes[n1]);
+                            if (HighlightedNodes.Contains(n2.Id))
+                            {
+                                DrawConnection(dc, pen2, n2, Skillnodes[n1]);
+                            }
                         }
                     }
                 }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -195,7 +195,7 @@ namespace POESKillTree.SkillTreeFiles
         private int _chartype;
         private List<SkillNode> _highlightnodes;
 
-        public int _level = 1;
+        private int _level = 1;
 
 
 

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -21,25 +21,20 @@ namespace POESKillTree.SkillTreeFiles
 
         public delegate void StartLoadingWindow();
 
-        public static float LifePerLevel = 12;
-        public static float AccPerLevel = 2;
-        public static float EvasPerLevel = 3;
-        public static float ManaPerLevel = 4;
-        public static float IntPerMana = 2;
-        public static float IntPerES = 5; //%
-        public static float StrPerLife = 2;
-        public static float StrPerED = 5; //%
-        public static float DexPerAcc = 0.5f;
-        public static float DexPerEvas = 5; //%
-        private static Action _emptyDelegate = delegate { };
-        private readonly Dictionary<string, Asset> _assets = new Dictionary<string, Asset>();
-        public List<string> AttributeTypes = new List<string>();
-        public List<int> rootNodeList = new List<int>();
-        public Dictionary<string, int> rootNodeClassDictionary = new Dictionary<string, int>();
-        public Dictionary<int, int> startNodeDictionary = new Dictionary<int, int>();
-        public HashSet<ushort> AvailNodes = new HashSet<ushort>();
+        public static readonly float LifePerLevel = 12;
+        public static readonly float AccPerLevel = 2;
+        public static readonly float EvasPerLevel = 3;
+        public static readonly float ManaPerLevel = 4;
+        public static readonly float IntPerMana = 2;
+        public static readonly float IntPerES = 5; //%
+        public static readonly float StrPerLife = 2;
+        public static readonly float StrPerED = 5; //%
+        public static readonly float DexPerAcc = 0.5f;
+        public static readonly float DexPerEvas = 5; //%
+        private const string TreeAddress = "http://www.pathofexile.com/passive-skill-tree/";
 
-        public Dictionary<string, float> BaseAttributes = new Dictionary<string, float>
+
+        public static readonly Dictionary<string, float> BaseAttributes = new Dictionary<string, float>
         {
             {"+# to maximum Mana", 36},
             {"+# to maximum Life", 38},
@@ -54,7 +49,7 @@ namespace POESKillTree.SkillTreeFiles
             {"#% Critical Strike Chance Increase per Power Charge", 50},
         };
 
-        private readonly Dictionary<string, List<string>> _hybridAttributes = new Dictionary<string, List<string>>
+        private static readonly Dictionary<string, List<string>> _hybridAttributes = new Dictionary<string, List<string>>
         {
             {
                "+# to Strength and Intelligence", 
@@ -76,9 +71,7 @@ namespace POESKillTree.SkillTreeFiles
             }
         };
 
-        public Dictionary<string, float>[] CharBaseAttributes = new Dictionary<string, float>[7];
-
-        public List<string> CharName = new List<string>
+        public static readonly List<string> CharName = new List<string>
         {
             "SEVEN",
             "MARAUDER",
@@ -89,7 +82,7 @@ namespace POESKillTree.SkillTreeFiles
             "SIX"
         };
 
-        public List<string> FaceNames = new List<string>
+        public static readonly List<string> FaceNames = new List<string>
         {
             "centerscion",
             "centermarauder",
@@ -100,229 +93,362 @@ namespace POESKillTree.SkillTreeFiles
             "centershadow"
         };
 
-        public HashSet<int[]> Links = new HashSet<int[]>();
-        public List<SkillNodeGroup> NodeGroups = new List<SkillNodeGroup>();
-        public HashSet<ushort> SkilledNodes = new HashSet<ushort>();
-
-        public HashSet<ushort> HighlightedNodes = new HashSet<ushort>();
-
-        public Dictionary<UInt16, SkillNode> Skillnodes = new Dictionary<UInt16, SkillNode>();
-
-        public Rect2D TRect = new Rect2D();
-        private const string TreeAddress = "http://www.pathofexile.com/passive-skill-tree/";
-        private int _chartype;
-        private List<SkillNode> _highlightnodes;
-        public SkillIcons IconActiveSkills = new SkillIcons();
-        public SkillIcons IconInActiveSkills = new SkillIcons();
-        public int _level = 1;
-
-        public Dictionary<string, string> NodeBackgrounds = new Dictionary<string, string>
+        public static readonly Dictionary<string, string> NodeBackgrounds = new Dictionary<string, string>
         {
             {"normal", "PSSkillFrame"},
             {"notable", "NotableFrameUnallocated"},
             {"keystone", "KeystoneFrameUnallocated"}
         };
 
-        public Dictionary<string, string> NodeBackgroundsActive = new Dictionary<string, string>
+        public static readonly Dictionary<string, string> NodeBackgroundsActive = new Dictionary<string, string>
         {
             {"normal", "PSSkillFrameActive"},
             {"notable", "NotableFrameAllocated"},
             {"keystone", "KeystoneFrameAllocated"}
         };
 
+        private static SkillIcons _IconActiveSkills;
+
+        public static SkillIcons IconActiveSkills
+        {
+            get { return SkillTree._IconActiveSkills; }
+        }
+        private static SkillIcons _IconInActiveSkills;
+
+        public static SkillIcons IconInActiveSkills
+        {
+            get { return SkillTree._IconInActiveSkills; }
+        }
+
+        private static Dictionary<UInt16, SkillNode> _Skillnodes;
+
+        public static Dictionary<UInt16, SkillNode> Skillnodes
+        {
+            get { return SkillTree._Skillnodes; }
+        }
+
+        private static Dictionary<string, float>[] _CharBaseAttributes;
+
+        public static Dictionary<string, float>[] CharBaseAttributes
+        {
+            get { return SkillTree._CharBaseAttributes; }
+        }
+
+        private static List<int> _rootNodeList;
+
+        public static List<int> rootNodeList
+        {
+            get { return SkillTree._rootNodeList; }
+        }
+
+        private static List<SkillNodeGroup> _NodeGroups;
+
+        public static List<SkillNodeGroup> NodeGroups
+        {
+            get { return SkillTree._NodeGroups; }
+        }
+
+
+        private static Rect2D _TRect;
+
+        public static Rect2D TRect
+        {
+            get { return SkillTree._TRect; }
+        }
+
+
+
+
+        public static Dictionary<string, int> rootNodeClassDictionary
+        {
+            get { return SkillTree._rootNodeClassDictionary; }
+        }
+
+        private static List<string> _AttributeTypes = new List<string>();
+
+        public static List<string> AttributeTypes
+        {
+            get { return _AttributeTypes; }
+        }
+
+        private static Dictionary<int, int> _startNodeDictionary = new Dictionary<int, int>();
+
+        public static Dictionary<int, int> startNodeDictionary
+        {
+            get { return SkillTree._startNodeDictionary; }
+        }
+
+        private static readonly Dictionary<string, Asset> _assets = new Dictionary<string, Asset>();
+
+        private static readonly Dictionary<string, int> _rootNodeClassDictionary = new Dictionary<string, int>();
+
+        private static readonly List<ushort[]> _links = new List<ushort[]>();
+
+
+
+        public HashSet<ushort> AvailNodes = new HashSet<ushort>();
+
+        public HashSet<ushort> SkilledNodes = new HashSet<ushort>();
+
+        public HashSet<ushort> HighlightedNodes = new HashSet<ushort>();
+
+        private int _chartype;
+        private List<SkillNode> _highlightnodes;
+
+        public int _level = 1;
+
+
+
         public float ScaleFactor = 1;
 
+
+        private static bool _Initialized = false;
         public SkillTree(String treestring, bool displayProgress, UpdateLoadingWindow update)
         {
-            var jss = new JsonSerializerSettings
+            PoESkillTree inTree = null;
+            if (!_Initialized)
             {
-                Error = delegate(object sender, ErrorEventArgs args)
+                var jss = new JsonSerializerSettings
                 {
-                    Debug.WriteLine(args.ErrorContext.Error.Message);
-                    args.ErrorContext.Handled = true;
-                }
-            };
+                    Error = delegate(object sender, ErrorEventArgs args)
+                    {
+                        Debug.WriteLine(args.ErrorContext.Error.Message);
+                        args.ErrorContext.Handled = true;
+                    }
+                };
 
-            var inTree = JsonConvert.DeserializeObject<PoESkillTree>(treestring.Replace("Additional ", ""), jss);
+                inTree = JsonConvert.DeserializeObject<PoESkillTree>(treestring.Replace("Additional ", ""), jss);
+            }
             int qindex = 0;
 
-            //TODO: (SpaceOgre) This is not used atm, so no need to run it.
-            foreach (var obj in inTree.skillSprites)
+            if (!_Initialized)
             {
-                if (obj.Key.Contains("inactive"))
-                    continue;
-                IconInActiveSkills.Images[obj.Value[3].filename] = null;
-                foreach (var o in obj.Value[3].coords)
+                SkillTree._IconInActiveSkills = new SkillIcons();
+                //TODO: (SpaceOgre) This is not used atm, so no need to run it.
+                foreach (var obj in inTree.skillSprites)
                 {
-                    IconInActiveSkills.SkillPositions[o.Key + "_" + o.Value.w] =
-                        new KeyValuePair<Rect, string>(new Rect(o.Value.x, o.Value.y, o.Value.w, o.Value.h),
-                            obj.Value[3].filename);
-                }
-            }
-            foreach (var obj in inTree.skillSprites)
-            {
-                if (obj.Key.Contains("active"))
-                    continue;
-                IconActiveSkills.Images[obj.Value[3].filename] = null;
-                foreach (var o in obj.Value[3].coords)
-                {
-                    IconActiveSkills.SkillPositions[o.Key + "_" + o.Value.w] =
-                        new KeyValuePair<Rect, string>(new Rect(o.Value.x, o.Value.y, o.Value.w, o.Value.h),
-                            obj.Value[3].filename);
+                    if (obj.Key.Contains("inactive"))
+                        continue;
+                    _IconInActiveSkills.Images[obj.Value[3].filename] = null;
+                    foreach (var o in obj.Value[3].coords)
+                    {
+                        _IconInActiveSkills.SkillPositions[o.Key + "_" + o.Value.w] =
+                            new KeyValuePair<Rect, string>(new Rect(o.Value.x, o.Value.y, o.Value.w, o.Value.h),
+                                obj.Value[3].filename);
+                    }
                 }
             }
 
-            foreach (var ass in inTree.assets)
+            if (!_Initialized)
             {
-                _assets[ass.Key] = new Asset(ass.Key,
-                    ass.Value.ContainsKey(0.3835f) ? ass.Value[0.3835f] : ass.Value.Values.First());
-            }
-            if (inTree.root != null)
-            {
-                foreach (int i in inTree.root.ot)
+                SkillTree._IconActiveSkills = new SkillIcons();
+                foreach (var obj in inTree.skillSprites)
                 {
-                    rootNodeList.Add(i);
+                    if (obj.Key.Contains("active"))
+                        continue;
+                    _IconActiveSkills.Images[obj.Value[3].filename] = null;
+                    foreach (var o in obj.Value[3].coords)
+                    {
+                        _IconActiveSkills.SkillPositions[o.Key + "_" + o.Value.w] =
+                            new KeyValuePair<Rect, string>(new Rect(o.Value.x, o.Value.y, o.Value.w, o.Value.h),
+                                obj.Value[3].filename);
+                    }
                 }
             }
-            else if (inTree.main != null)
+
+            if (!_Initialized)
             {
-                foreach (int i in inTree.main.ot)
+                foreach (var ass in inTree.assets)
                 {
-                    rootNodeList.Add(i);
+                    _assets[ass.Key] = new Asset(ass.Key,
+                        ass.Value.ContainsKey(0.3835f) ? ass.Value[0.3835f] : ass.Value.Values.First());
+                }
+            }
+
+            if (!_Initialized)
+            {
+                _rootNodeList = new List<int>();
+                if (inTree.root != null)
+                {
+                    foreach (int i in inTree.root.ot)
+                    {
+                        _rootNodeList.Add(i);
+                    }
+                }
+                else if (inTree.main != null)
+                {
+                    foreach (int i in inTree.main.ot)
+                    {
+                        _rootNodeList.Add(i);
+                    }
                 }
             }
 
             if (displayProgress)
                 update(50, 100);
-            IconActiveSkills.OpenOrDownloadImages(update);
+
+            if (!_Initialized)
+                _IconActiveSkills.OpenOrDownloadImages(update);
+
             if (displayProgress)
                 update(75, 100);
-            IconInActiveSkills.OpenOrDownloadImages(update);
-            foreach (var c in inTree.characterData)
+
+            if (!_Initialized)
+                _IconInActiveSkills.OpenOrDownloadImages(update);
+
+
+            if (!_Initialized)
             {
-                CharBaseAttributes[c.Key] = new Dictionary<string, float>
+                _CharBaseAttributes = new Dictionary<string, float>[7];
+                foreach (var c in inTree.characterData)
+                {
+                    _CharBaseAttributes[c.Key] = new Dictionary<string, float>
                 {
                     {"+# to Strength", c.Value.base_str},
                     {"+# to Dexterity", c.Value.base_dex},
                     {"+# to Intelligence", c.Value.base_int}
                 };
+                }
             }
-            foreach (Node nd in inTree.nodes)
+
+
+
+            if (!_Initialized)
             {
-                Skillnodes.Add(nd.id, new SkillNode
+                _Skillnodes = new Dictionary<ushort, SkillNode>();
+                foreach (Node nd in inTree.nodes)
                 {
-                    Id = nd.id,
-                    Name = nd.dn,
-                    attributes = nd.sd,
-                    Orbit = nd.o,
-                    OrbitIndex = nd.oidx,
-                    Icon = nd.icon,
-                    LinkId = nd.ot,
-                    G = nd.g,
-                    Da = nd.da,
-                    Ia = nd.ia,
-                    IsKeyStone = nd.ks,
-                    IsNotable = nd.not,
-                    Sa = nd.sa,
-                    IsMastery = nd.m,
-                    Spc = nd.spc.Count() > 0 ? (int?) nd.spc[0] : null
-                });
-                if (rootNodeList.Contains(nd.id))
-                {
-                    rootNodeClassDictionary.Add(nd.dn.ToString().ToUpper(), nd.id);
-                    foreach (int linkedNode in nd.ot)
+                    _Skillnodes.Add(nd.id, new SkillNode
                     {
-                        startNodeDictionary.Add(linkedNode, nd.id);
+                        Id = nd.id,
+                        Name = nd.dn,
+                        attributes = nd.sd,
+                        Orbit = nd.o,
+                        OrbitIndex = nd.oidx,
+                        Icon = nd.icon,
+                        LinkId = nd.ot,
+                        G = nd.g,
+                        Da = nd.da,
+                        Ia = nd.ia,
+                        IsKeyStone = nd.ks,
+                        IsNotable = nd.not,
+                        Sa = nd.sa,
+                        IsMastery = nd.m,
+                        Spc = nd.spc.Count() > 0 ? (int?)nd.spc[0] : null
+                    });
+                    if (_rootNodeList.Contains(nd.id))
+                    {
+                        _rootNodeClassDictionary.Add(nd.dn.ToString().ToUpper(), nd.id);
+                        foreach (int linkedNode in nd.ot)
+                        {
+                            _startNodeDictionary.Add(linkedNode, nd.id);
+                        }
+                    }
+                    foreach (int node in nd.ot)
+                    {
+                        if (!_startNodeDictionary.ContainsKey(nd.id) && _rootNodeList.Contains(node))
+                        {
+                            _startNodeDictionary.Add(nd.id, node);
+                        }
+                    }
+
+                }
+
+
+                foreach (var skillNode in Skillnodes)
+                {
+                    foreach (ushort i in skillNode.Value.LinkId)
+                    {
+                        if (
+                            _links.Count(nd => (nd[0] == i && nd[1] == skillNode.Key) || nd[0] == skillNode.Key && nd[1] == i) ==
+                            1)
+                        {
+                            continue;
+                        }
+                        _links.Add(new[] { skillNode.Key, i });
                     }
                 }
-                foreach (int node in nd.ot)
+                foreach (var ints in _links)
                 {
-                    if (!startNodeDictionary.ContainsKey(nd.id) && rootNodeList.Contains(node))
+                    if (!Skillnodes[ints[0]].Neighbor.Contains(Skillnodes[ints[1]]))
+                        Skillnodes[ints[0]].Neighbor.Add(Skillnodes[ints[1]]);
+                    if (!Skillnodes[ints[1]].Neighbor.Contains(Skillnodes[ints[0]]))
+                        Skillnodes[ints[1]].Neighbor.Add(Skillnodes[ints[0]]);
+                }
+            }
+
+
+
+            if (!_Initialized)
+            {
+                _NodeGroups = new List<SkillNodeGroup>();
+                foreach (var gp in inTree.groups)
+                {
+                    var ng = new SkillNodeGroup();
+
+                    ng.OcpOrb = gp.Value.oo;
+                    ng.Position = new Vector2D(gp.Value.x, gp.Value.y);
+                    ng.Nodes = gp.Value.n;
+                    NodeGroups.Add(ng);
+                }
+                foreach (SkillNodeGroup group in NodeGroups)
+                {
+                    foreach (ushort node in group.Nodes)
                     {
-                        startNodeDictionary.Add(nd.id, node);
+                        Skillnodes[node].SkillNodeGroup = group;
                     }
                 }
 
             }
-            var links = new List<ushort[]>();
-            foreach (var skillNode in Skillnodes)
+
+            if (!_Initialized)
             {
-                foreach (ushort i in skillNode.Value.LinkId)
-                {
-                    if (
-                        links.Count(nd => (nd[0] == i && nd[1] == skillNode.Key) || nd[0] == skillNode.Key && nd[1] == i) ==
-                        1)
-                    {
-                        continue;
-                    }
-                    links.Add(new[] {skillNode.Key, i});
-                }
-            }
-            foreach (var ints in links)
-            {
-                if (!Skillnodes[ints[0]].Neighbor.Contains(Skillnodes[ints[1]]))
-                    Skillnodes[ints[0]].Neighbor.Add(Skillnodes[ints[1]]);
-                if (!Skillnodes[ints[1]].Neighbor.Contains(Skillnodes[ints[0]]))
-                    Skillnodes[ints[1]].Neighbor.Add(Skillnodes[ints[0]]);
+                _TRect = new Rect2D(new Vector2D(inTree.min_x * 1.1, inTree.min_y * 1.1),
+                    new Vector2D(inTree.max_x * 1.1, inTree.max_y * 1.1));
             }
 
-            foreach (var gp in inTree.groups)
-            {
-                var ng = new SkillNodeGroup();
 
-                ng.OcpOrb = gp.Value.oo;
-                ng.Position = new Vector2D(gp.Value.x, gp.Value.y);
-                ng.Nodes = gp.Value.n;
-                NodeGroups.Add(ng);
-            }
+            InitNodeSurround();//
 
-            foreach (SkillNodeGroup group in NodeGroups)
-            {
-                foreach (ushort node in group.Nodes)
-                {
-                    Skillnodes[node].SkillNodeGroup = group;
-                }
-            }
-            TRect = new Rect2D(new Vector2D(inTree.min_x*1.1, inTree.min_y*1.1),
-                new Vector2D(inTree.max_x*1.1, inTree.max_y*1.1));
-
-
-            InitNodeSurround();
             DrawNodeSurround();
             DrawNodeBaseSurround();
             InitSkillIconLayers();
             DrawSkillIconLayer();
             DrawBackgroundLayer();
             InitFaceBrushesAndLayer();
-            DrawLinkBackgroundLayer(links);
+            DrawLinkBackgroundLayer(_links);
             InitOtherDynamicLayers();
             CreateCombineVisual();
 
-
-            var regexAttrib = new Regex("[0-9]*\\.?[0-9]+");
-            foreach (var skillNode in Skillnodes)
+            if (_links != null)
             {
-                skillNode.Value.Attributes = new Dictionary<string, List<float>>();
-                foreach (string s in skillNode.Value.attributes)
+                var regexAttrib = new Regex("[0-9]*\\.?[0-9]+");
+                foreach (var skillNode in Skillnodes)
                 {
-                    var values = new List<float>();
-
-                    foreach (Match m in regexAttrib.Matches(s))
+                    skillNode.Value.Attributes = new Dictionary<string, List<float>>();
+                    foreach (string s in skillNode.Value.attributes)
                     {
-                        if (!AttributeTypes.Contains(regexAttrib.Replace(s, "#")))
-                            AttributeTypes.Add(regexAttrib.Replace(s, "#"));
-                        if (m.Value == "")
-                            values.Add(float.NaN);
-                        else
-                            values.Add(float.Parse(m.Value, CultureInfo.InvariantCulture));
-                    }
-                    string cs = (regexAttrib.Replace(s, "#"));
+                        var values = new List<float>();
 
-                    skillNode.Value.Attributes[cs] = values;
+                        foreach (Match m in regexAttrib.Matches(s))
+                        {
+                            if (!AttributeTypes.Contains(regexAttrib.Replace(s, "#")))
+                                AttributeTypes.Add(regexAttrib.Replace(s, "#"));
+                            if (m.Value == "")
+                                values.Add(float.NaN);
+                            else
+                                values.Add(float.Parse(m.Value, CultureInfo.InvariantCulture));
+                        }
+                        string cs = (regexAttrib.Replace(s, "#"));
+
+                        skillNode.Value.Attributes[cs] = values;
+                    }
                 }
             }
             if (displayProgress)
                 update(100, 100);
+
+            _Initialized = true;
         }
 
         public int Level
@@ -353,81 +479,92 @@ namespace POESKillTree.SkillTreeFiles
         {
             get
             {
-                Dictionary<string, List<float>> temp = SelectedAttributesWithoutImplicit;
+                return GetAttributes(SkilledNodes, Chartype, _level);
+            }
+        }
 
-                foreach (var a in ImplicitAttributes(temp))
+        public static Dictionary<string, List<float>> GetAttributes(IEnumerable<ushort> skilledNodes, int chartype, int level)
+        {
+            Dictionary<string, List<float>> temp = GetAttributesWithoutImplicit(skilledNodes,chartype);
+
+            foreach (var a in ImplicitAttributes(temp, level))
+            {
+                string key = RenameImplicitAttributes.ContainsKey(a.Key) ? RenameImplicitAttributes[a.Key] : a.Key;
+
+                if (!temp.ContainsKey(key))
+                    temp[key] = new List<float>();
+                for (int i = 0; i < a.Value.Count; i++)
                 {
-                    string key = RenameImplicitAttributes.ContainsKey(a.Key) ? RenameImplicitAttributes[a.Key] : a.Key;
-
-                    if (!temp.ContainsKey(key))
-                        temp[key] = new List<float>();
-                    for (int i = 0; i < a.Value.Count; i++)
+                    if (temp.ContainsKey(key) && temp[key].Count > i)
+                        temp[key][i] += a.Value[i];
+                    else
                     {
-                        if (temp.ContainsKey(key) && temp[key].Count > i)
-                            temp[key][i] += a.Value[i];
-                        else
-                        {
-                            temp[key].Add(a.Value[i]);
-                        }
+                        temp[key].Add(a.Value[i]);
                     }
                 }
-                return temp;
             }
+            return temp;
         }
 
         public Dictionary<string, List<float>> SelectedAttributesWithoutImplicit
         {
             get
             {
-                var temp = new Dictionary<string, List<float>>();
+                return GetAttributesWithoutImplicit(SkilledNodes,Chartype);
+            }
+        }
 
-                foreach (var attr in CharBaseAttributes[Chartype])
+
+        public static Dictionary<string, List<float>> GetAttributesWithoutImplicit( IEnumerable<ushort> skilledNodes, int chartype)
+        {
+            var temp = new Dictionary<string, List<float>>();
+
+            foreach (var attr in CharBaseAttributes[chartype])
+            {
+                if (!temp.ContainsKey(attr.Key))
+                    temp[attr.Key] = new List<float>();
+
+                if (temp.ContainsKey(attr.Key) && temp[attr.Key].Count > 0)
+                    temp[attr.Key][0] += attr.Value;
+                else
+                {
+                    temp[attr.Key].Add(attr.Value);
+                }
+            }
+
+            foreach (var attr in BaseAttributes)
+            {
+                if (!temp.ContainsKey(attr.Key))
+                    temp[attr.Key] = new List<float>();
+
+                if (temp.ContainsKey(attr.Key) && temp[attr.Key].Count > 0)
+                    temp[attr.Key][0] += attr.Value;
+                else
+                {
+                    temp[attr.Key].Add(attr.Value);
+                }
+            }
+
+            foreach (ushort inode in skilledNodes)
+            {
+                SkillNode node = Skillnodes[inode];
+                foreach (var attr in ExpandHybridAttributes(node.Attributes))
                 {
                     if (!temp.ContainsKey(attr.Key))
                         temp[attr.Key] = new List<float>();
-
-                    if (temp.ContainsKey(attr.Key) && temp[attr.Key].Count > 0)
-                        temp[attr.Key][0] += attr.Value;
-                    else
+                    for (int i = 0; i < attr.Value.Count; i++)
                     {
-                        temp[attr.Key].Add(attr.Value);
-                    }
-                }
-
-                foreach (var attr in BaseAttributes)
-                {
-                    if (!temp.ContainsKey(attr.Key))
-                        temp[attr.Key] = new List<float>();
-
-                    if (temp.ContainsKey(attr.Key) && temp[attr.Key].Count > 0)
-                        temp[attr.Key][0] += attr.Value;
-                    else
-                    {
-                        temp[attr.Key].Add(attr.Value);
-                    }
-                }
-
-                foreach (ushort inode in SkilledNodes)
-                {
-                    SkillNode node = Skillnodes[inode];
-                    foreach (var attr in ExpandHybridAttributes(node.Attributes))
-                    {
-                        if (!temp.ContainsKey(attr.Key))
-                            temp[attr.Key] = new List<float>();
-                        for (int i = 0; i < attr.Value.Count; i++)
+                        if (temp.ContainsKey(attr.Key) && temp[attr.Key].Count > i)
+                            temp[attr.Key][i] += attr.Value[i];
+                        else
                         {
-                            if (temp.ContainsKey(attr.Key) && temp[attr.Key].Count > i)
-                                temp[attr.Key][i] += attr.Value[i];
-                            else
-                            {
-                                temp[attr.Key].Add(attr.Value[i]);
-                            }
+                            temp[attr.Key].Add(attr.Value[i]);
                         }
                     }
                 }
-
-                return temp;
             }
+
+            return temp;
         }
 
         public static SkillTree CreateSkillTree(StartLoadingWindow start = null, UpdateLoadingWindow update = null,
@@ -458,8 +595,8 @@ namespace POESKillTree.SkillTreeFiles
                 if (displayProgress)
                     start();
                 string uriString = "http://www.pathofexile.com/passive-skill-tree/";
-                var req = (HttpWebRequest) WebRequest.Create(uriString);
-                var resp = (HttpWebResponse) req.GetResponse();
+                var req = (HttpWebRequest)WebRequest.Create(uriString);
+                var resp = (HttpWebResponse)req.GetResponse();
                 string code = new StreamReader(resp.GetResponseStream()).ReadToEnd();
                 var regex = new Regex("var passiveSkillTreeData.*");
                 skilltreeobj = regex.Match(code).Value.Replace("root", "main").Replace("\\/", "/");
@@ -550,7 +687,7 @@ namespace POESKillTree.SkillTreeFiles
             if (SkilledNodes.Contains(targetNode))
                 return new List<ushort>();
             if (AvailNodes.Contains(targetNode))
-                return new List<ushort> {targetNode};
+                return new List<ushort> { targetNode };
 
             var visited = new HashSet<ushort>(SkilledNodes);
             var distance = new Dictionary<int, int>();
@@ -594,7 +731,7 @@ namespace POESKillTree.SkillTreeFiles
                 return new List<ushort>();
 
             var curr = targetNode;
-            var result = new List<ushort> {curr};
+            var result = new List<ushort> { curr };
             while (parent.ContainsKey(curr))
             {
                 result.Add(parent[curr]);
@@ -642,13 +779,13 @@ namespace POESKillTree.SkillTreeFiles
             }
         }
 
-        public Dictionary<string, List<float>> ImplicitAttributes(Dictionary<string, List<float>> attribs)
+        public static Dictionary<string, List<float>> ImplicitAttributes(Dictionary<string, List<float>> attribs, int level)
         {
             var retval = new Dictionary<string, List<float>>();
             // +# to Strength", co["base_str"].Value<int>() }, { "+# to Dexterity", co["base_dex"].Value<int>() }, { "+# to Intelligence", co["base_int"].Value<int>() } };
             retval["+# to maximum Mana"] = new List<float>
             {
-                attribs["+# to Intelligence"][0]/IntPerMana + _level*ManaPerLevel
+                attribs["+# to Intelligence"][0]/IntPerMana + level*ManaPerLevel
             };
             retval["#% increased maximum Energy Shield"] = new List<float>
             {
@@ -657,38 +794,40 @@ namespace POESKillTree.SkillTreeFiles
 
             retval["+# to maximum Life"] = new List<float>
             {
-                attribs["+# to Strength"][0]/StrPerLife + _level*LifePerLevel
+                attribs["+# to Strength"][0]/StrPerLife + level*LifePerLevel
             };
             // Every 10 strength grants 2% increased melee physical damage. 
-            var str = (int) attribs["+# to Strength"][0];
-            if (str%(int) StrPerED > 0) str += (int) StrPerED - (str%(int) StrPerED);
-            retval["#% increased Melee Physical Damage"] = new List<float> {str/StrPerED};
+            var str = (int)attribs["+# to Strength"][0];
+            if (str % (int)StrPerED > 0) str += (int)StrPerED - (str % (int)StrPerED);
+            retval["#% increased Melee Physical Damage"] = new List<float> { str / StrPerED };
             // Every point of Dexterity gives 2 additional base accuracy, and characters gain 2 base accuracy when leveling up.
             // @see http://pathofexile.gamepedia.com/Accuracy
             retval["+# Accuracy Rating"] = new List<float>
             {
-                attribs["+# to Dexterity"][0]/DexPerAcc + (_level - 1)*AccPerLevel
+                attribs["+# to Dexterity"][0]/DexPerAcc + (level - 1)*AccPerLevel
             };
-            retval["Evasion Rating: #"] = new List<float> {_level*EvasPerLevel};
+            retval["Evasion Rating: #"] = new List<float> { level * EvasPerLevel };
 
             // Dexterity value is not getting rounded up any more but rounded normally to the nearest multiple of 5.
             // @see http://pathofexile.gamepedia.com/Talk:Evasion
             float dex = attribs["+# to Dexterity"][0];
-            dex = (float) Math.Round(dex/DexPerEvas, 0, MidpointRounding.AwayFromZero)*DexPerEvas;
-            retval["#% increased Evasion Rating"] = new List<float> {dex/DexPerEvas};
+            dex = (float)Math.Round(dex / DexPerEvas, 0, MidpointRounding.AwayFromZero) * DexPerEvas;
+            retval["#% increased Evasion Rating"] = new List<float> { dex / DexPerEvas };
 
             return retval;
         }
 
-        public void LoadFromURL(string url)
+
+        public static void DecodeURL(string url, out HashSet<ushort> skillednodes, out int chartype)
         {
+            skillednodes = new HashSet<ushort>();
             url = Regex.Replace(url, @"\t| |\n|\r", "");
             string s =
                 url.Substring(TreeAddress.Length + (url.StartsWith("https") ? 1 : 0))
                     .Replace("-", "+")
                     .Replace("_", "/");
             byte[] decbuff = Convert.FromBase64String(s);
-            int i = BitConverter.ToInt32(new[] {decbuff[3], decbuff[2], decbuff[1], decbuff[1]}, 0);
+            int i = BitConverter.ToInt32(new[] { decbuff[3], decbuff[2], decbuff[1], decbuff[1] }, 0);
             byte b = decbuff[4];
             long j = 0L;
             if (i > 0)
@@ -696,18 +835,31 @@ namespace POESKillTree.SkillTreeFiles
             var nodes = new List<UInt16>();
             for (int k = 6; k < decbuff.Length; k += 2)
             {
-                byte[] dbff = {decbuff[k + 1], decbuff[k + 0]};
+                byte[] dbff = { decbuff[k + 1], decbuff[k + 0] };
                 if (Skillnodes.Keys.Contains(BitConverter.ToUInt16(dbff, 0)))
                     nodes.Add((BitConverter.ToUInt16(dbff, 0)));
             }
-            Chartype = b;
-            SkilledNodes.Clear();
-            SkillNode startnode = Skillnodes.First(nd => nd.Value.Name.ToUpper() == CharName[Chartype].ToUpper()).Value;
-            SkilledNodes.Add(startnode.Id);
+            chartype = b;
+
+
+            SkillNode startnode = Skillnodes.First(nd => nd.Value.Name.ToUpper() == CharName[b].ToUpper()).Value;
+            skillednodes.Add(startnode.Id);
             foreach (ushort node in nodes)
             {
-                SkilledNodes.Add(node);
+                skillednodes.Add(node);
             }
+
+        }
+
+
+        public void LoadFromURL(string url)
+        {
+            int b;
+            HashSet<ushort> snodes;
+            SkillTree.DecodeURL(url, out snodes, out b);
+            Chartype = b;
+            SkilledNodes = snodes;
+            
             UpdateAvailNodes();
         }
 
@@ -721,20 +873,20 @@ namespace POESKillTree.SkillTreeFiles
 
         public string SaveToURL()
         {
-            var b = new byte[(SkilledNodes.Count - 1)*2 + 6];
+            var b = new byte[(SkilledNodes.Count - 1) * 2 + 6];
             byte[] b2 = BitConverter.GetBytes(2);
             b[0] = b2[3];
             b[1] = b2[2];
             b[2] = b2[1];
             b[3] = b2[0];
-            b[4] = (byte) (Chartype);
+            b[4] = (byte)(Chartype);
             b[5] = 0;
             int pos = 6;
             foreach (ushort inn in SkilledNodes)
             {
                 if (CharName.Contains(Skillnodes[inn].Name.ToUpper()))
                     continue;
-                byte[] dbff = BitConverter.GetBytes((Int16) inn);
+                byte[] dbff = BitConverter.GetBytes((Int16)inn);
                 b[pos++] = dbff[1];
                 b[pos++] = dbff[0];
             }
@@ -748,7 +900,7 @@ namespace POESKillTree.SkillTreeFiles
             var nodes = new HashSet<int>();
             foreach (SkillNode nd in _highlightnodes)
             {
-                if(!rootNodeList.Contains(nd.Id))
+                if (!rootNodeList.Contains(nd.Id))
                     nodes.Add(nd.Id);
             }
             SkillNodeList(nodes);
@@ -791,7 +943,7 @@ namespace POESKillTree.SkillTreeFiles
         public void UpdateAvailNodes(bool draw = true)
         {
             UpdateAvailNodesList();
-            if(draw)
+            if (draw)
                 UpdateAvailNodesDraw();
         }
 
@@ -830,7 +982,7 @@ namespace POESKillTree.SkillTreeFiles
             DrawNodeSurround();
         }
 
-        private Dictionary<string, List<float>> ExpandHybridAttributes(Dictionary<string, List<float>> attributes)
+        private static Dictionary<string, List<float>> ExpandHybridAttributes(Dictionary<string, List<float>> attributes)
         {
             foreach (var attribute in attributes.ToList())
             {
@@ -854,21 +1006,21 @@ namespace POESKillTree.SkillTreeFiles
             int rootNodeValue;
             var temp = new List<ushort>();
 
-            if(className.ToUpper() == "SHADOW")
+            if (className.ToUpper() == "SHADOW")
             {
                 className = "SIX";
             }
-            if(className.ToUpper() == "SCION")
+            if (className.ToUpper() == "SCION")
             {
                 className = "SEVEN";
             }
-            rootNodeClassDictionary.TryGetValue(className.ToUpper(), out rootNodeValue);
-            var classSpecificStartNodes = startNodeDictionary.Where(kvp => kvp.Value == rootNodeValue).Select(kvp => kvp.Key);
+            _rootNodeClassDictionary.TryGetValue(className.ToUpper(), out rootNodeValue);
+            var classSpecificStartNodes = _startNodeDictionary.Where(kvp => kvp.Value == rootNodeValue).Select(kvp => kvp.Key);
 
             foreach (int node in classSpecificStartNodes)
             {
-                temp = GetShortestPathTo((ushort) node);
-                
+                temp = GetShortestPathTo((ushort)node);
+
                 if (!temp.Any())
                     return true;
             }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -103,6 +103,9 @@ namespace POESKillTree.SkillTreeFiles
         public HashSet<int[]> Links = new HashSet<int[]>();
         public List<SkillNodeGroup> NodeGroups = new List<SkillNodeGroup>();
         public HashSet<ushort> SkilledNodes = new HashSet<ushort>();
+
+        public HashSet<ushort> HighlightedNodes = new HashSet<ushort>();
+
         public Dictionary<UInt16, SkillNode> Skillnodes = new Dictionary<UInt16, SkillNode>();
 
         public Rect2D TRect = new Rect2D();
@@ -343,6 +346,9 @@ namespace POESKillTree.SkillTreeFiles
             }
         }
 
+
+        public Dictionary<string, List<float>> HighlightedAttributes;
+
         public Dictionary<string, List<float>> SelectedAttributes
         {
             get
@@ -374,6 +380,7 @@ namespace POESKillTree.SkillTreeFiles
             get
             {
                 var temp = new Dictionary<string, List<float>>();
+
                 foreach (var attr in CharBaseAttributes[Chartype])
                 {
                     if (!temp.ContainsKey(attr.Key))

--- a/WPFSKillTree/SkillTreeFiles/SkillTreeImporter.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTreeImporter.cs
@@ -123,7 +123,7 @@ namespace POESKillTree.SkillTreeFiles
             }
 
             double nminx = float.MaxValue, nminy = float.MaxValue, nmaxx = float.MinValue, nmaxy = float.MinValue;
-            foreach (SkillNode node in tree.Skillnodes.Values)
+            foreach (SkillNode node in SkillTree.Skillnodes.Values)
             {
                 Vector2D pos = node.Position;
                 nminx = Math.Min(pos.X, nminx);
@@ -140,7 +140,7 @@ namespace POESKillTree.SkillTreeFiles
             tree.Chartype = character;
             tree.SkilledNodes.Clear();
             SkillNode startnode =
-                tree.Skillnodes.First(nd => nd.Value.Name == tree.CharName[tree.Chartype].ToUpper()).Value;
+                SkillTree.Skillnodes.First(nd => nd.Value.Name == SkillTree.CharName[tree.Chartype].ToUpper()).Value;
             tree.SkilledNodes.Add(startnode.Id);
 
             for (int i = 1; i < buildResp.Length; ++i)
@@ -151,7 +151,7 @@ namespace POESKillTree.SkillTreeFiles
                                       new Vector2D(1/(maxx - minx), 1/(maxy - miny));
                 double minDis = 2;
                 var minNode = new KeyValuePair<ushort, SkillNode>();
-                foreach (var node in tree.Skillnodes)
+                foreach (var node in SkillTree.Skillnodes)
                 {
                     Vector2D nodePos = (node.Value.Position - new Vector2D(nminx, nminy))*
                                        new Vector2D(1/(nmaxx - nminx), 1/(nmaxy - nminy));

--- a/WPFSKillTree/Utils/GroupStringConverter.cs
+++ b/WPFSKillTree/Utils/GroupStringConverter.cs
@@ -15,6 +15,7 @@ namespace POESKillTree.Utils
         public Dictionary<string, AttributeGroup> AttributeGroups = new Dictionary<string, AttributeGroup>();
         private static readonly List<string[]> Groups = new List<string[]>
         {
+            new[] {"Share Endurance, Frenzy and Power Charges with nearby party members", "Keystone"},
             new[] {"and Endurance Charges on Hit with Claws", "Weapon"},
             new[] {"Endurance Charge", "Charges"},
             new[] {"Frenzy Charge", "Charges"},

--- a/WPFSKillTree/ViewModels/Attribute.cs
+++ b/WPFSKillTree/ViewModels/Attribute.cs
@@ -4,7 +4,7 @@ namespace POESKillTree.ViewModels
     {
         public string Text { get; set; }
         public float[] Deltas { get; set; }
-
+        public bool Missing { get; set; }
         public Attribute(string text)
         {
             Text = text;
@@ -14,5 +14,7 @@ namespace POESKillTree.ViewModels
         {
             return Text;
         }
+
+
     }
 }

--- a/WPFSKillTree/ViewModels/Attribute.cs
+++ b/WPFSKillTree/ViewModels/Attribute.cs
@@ -3,6 +3,7 @@ namespace POESKillTree.ViewModels
     internal class Attribute
     {
         public string Text { get; set; }
+        public float[] Deltas { get; set; }
 
         public Attribute(string text)
         {

--- a/WPFSKillTree/ViewModels/Converters.cs
+++ b/WPFSKillTree/ViewModels/Converters.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace POESKillTree.ViewModels
+{
+    class SignConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is float)
+            {
+                float val = (float)value;
+                if (targetType == typeof(Brush))
+                {
+                    if (val == 0)
+                        return Brushes.White;
+
+                    if (val > 0)
+                        return Brushes.Green;
+
+                    if (val < 0)
+                        return Brushes.Red;
+                }
+                if (targetType == typeof(Color))
+                {
+                    if (val == 0)
+                        return Colors.White;
+
+                    if (val > 0)
+                        return Colors.Green;
+
+                    if (val < 0)
+                        return Colors.Red;
+                }
+                else if (targetType == typeof(Visibility))
+                {
+                    if (val == 0)
+                        return Visibility.Collapsed;
+
+                    return Visibility.Visible;
+                }
+                else if (targetType == typeof(int))
+                {
+                    if (val == 0)
+                        return 0;
+
+                    if (val > 0)
+                        return 1;
+
+                    if (val < 0)
+                        return -1;
+                }
+
+                throw new NotImplementedException("cannot convert to target type '" + targetType.Name + "'");
+            }
+
+            throw new NotImplementedException("can convert only from floats");
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    class ArrayToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value == null)
+                return Visibility.Collapsed;
+
+            if (value is Array)
+            {
+                bool allzeros = false;
+                if(value is float[])
+                    allzeros = ((float[])value).All(v=>v==0f);
+                else if (value is int[])
+                    allzeros = ((int[])value).All(v => v == 0f);
+                else if (value is double[])
+                    allzeros = ((double[])value).All(v => v == 0.0);
+
+                if (allzeros)
+                    return Visibility.Collapsed;
+
+                if (((Array)value).Length != 0)
+                    return Visibility.Visible;
+            }
+
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/WPFSKillTree/ViewModels/Converters.cs
+++ b/WPFSKillTree/ViewModels/Converters.cs
@@ -3,96 +3,42 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Documents;
 using System.Windows.Media;
+using System.Windows.Media.TextFormatting;
 
 namespace POESKillTree.ViewModels
 {
-    class SignConverter : IValueConverter
+    class AttributeToTextblockConverter:IValueConverter
     {
+
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (value is float)
+            var attr = value as Attribute;
+            if (attr == null)
+                throw new NotImplementedException();
+
+            var tb = new TextBlock(){TextWrapping= TextWrapping.Wrap};
+            var txt = new Run(attr.Text);
+            if (attr.Missing)
+                txt.Foreground = Brushes.Red;
+
+            tb.Inlines.Add(txt);
+
+            foreach (var i in attr.Deltas)
             {
-                float val = (float)value;
-                if (targetType == typeof(Brush))
+                if (i != 0)
                 {
-                    if (val == 0)
-                        return Brushes.White;
-
-                    if (val > 0)
-                        return Brushes.Green;
-
-                    if (val < 0)
-                        return Brushes.Red;
+                    tb.Inlines.Add(" ");
+                    txt = new Run(i.ToString("+#;-#;0"));
+                    txt.Foreground = (i < 0) ? Brushes.Red : Brushes.Green;
+                    tb.Inlines.Add(txt);
                 }
-                if (targetType == typeof(Color))
-                {
-                    if (val == 0)
-                        return Colors.White;
-
-                    if (val > 0)
-                        return Colors.Green;
-
-                    if (val < 0)
-                        return Colors.Red;
-                }
-                else if (targetType == typeof(Visibility))
-                {
-                    if (val == 0)
-                        return Visibility.Collapsed;
-
-                    return Visibility.Visible;
-                }
-                else if (targetType == typeof(int))
-                {
-                    if (val == 0)
-                        return 0;
-
-                    if (val > 0)
-                        return 1;
-
-                    if (val < 0)
-                        return -1;
-                }
-
-                throw new NotImplementedException("cannot convert to target type '" + targetType.Name + "'");
             }
 
-            throw new NotImplementedException("can convert only from floats");
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    class ArrayToVisibilityConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            if (value == null)
-                return Visibility.Collapsed;
-
-            if (value is Array)
-            {
-                bool allzeros = false;
-                if(value is float[])
-                    allzeros = ((float[])value).All(v=>v==0f);
-                else if (value is int[])
-                    allzeros = ((int[])value).All(v => v == 0f);
-                else if (value is double[])
-                    allzeros = ((double[])value).All(v => v == 0.0);
-
-                if (allzeros)
-                    return Visibility.Collapsed;
-
-                if (((Array)value).Length != 0)
-                    return Visibility.Visible;
-            }
-
-            return Visibility.Collapsed;
+            return tb;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -10,10 +10,12 @@
         Title="Path of Exile - Passive Skill Tree Planner" Height="667" Width="1200" SizeChanged="Window_SizeChanged" 
         Closing="Window_Closing" Icon="/POESKillTree;component/logo.ico" Loaded="Window_Loaded" WindowStartupLocation="CenterScreen"
         PreviewKeyDown="Window_PreviewKeyDown"
-        TextOptions.TextFormattingMode="Display">
+        TextOptions.TextFormattingMode="Display"
+        x:Name="window"
+        >
     <Window.Resources>
         <conv:AttributeToTextblockConverter x:Key="attributeToTextblockConverter" />
-        
+
         <Style x:Key="ContainerStyleIsExpanded" TargetType="{x:Type GroupItem}">
             <Setter Property="Template">
                 <Setter.Value>
@@ -222,6 +224,7 @@
                 <Separator />
                 <MenuItem x:Name="mnuViewBuilds" Header="_Builds" InputGestureText="Ctrl+B" IsCheckable="true" IsChecked="False" Click="ToggleBuilds_Click"/>
                 <MenuItem x:Name="mnuViewAttributes" Header="_Attributes" IsCheckable="true" IsChecked="False" InputGestureText="Ctrl+Q" Click="ToggleAttributes_Click"/>
+                <MenuItem x:Name="mnuViewComparison" Header="_Tree comparison" IsCheckable="true" IsChecked="{Binding PersistentData.Options.TreeComparisonEnabled,ElementName=window, Mode=TwoWay}" Checked="ToggleTreeComparison_Click" Unchecked="ToggleTreeComparison_Click"  />
             </MenuItem>
             <MenuItem Header="_Tools ">
                 <MenuItem Header="_ScreenShot of Skilled Nodes" Click="Menu_ScreenShot">
@@ -312,10 +315,16 @@
                 </Expander.Header>
 
                 <Grid x:Name="gridBuildManager" HorizontalAlignment="Left"  FlowDirection="LeftToRight" Background="{DynamicResource WhiteColorBrush}">
-                    <ListView x:Name="lvSavedBuilds" Margin="0,0,0,31" HorizontalAlignment="Left" Width="255"
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="auto"/>
+                        <RowDefinition Height="auto"/>
+                    </Grid.RowDefinitions>
+                    <ListView x:Name="lvSavedBuilds" Margin="0,0,0,2.476" HorizontalAlignment="Left" Width="255" Grid.Row="0"
                               ForceCursor="True" KeyUp="lvSavedBuilds_KeyUp" IsSynchronizedWithCurrentItem="True" BorderThickness="0"
                               AllowDrop="True" DragEnter="ListViewDragEnter" Drop="ListViewDrop" PreviewMouseMove="ListViewPreviewMouseMove" PreviewMouseLeftButtonDown="ListViewMouseLeftButtonDown"
-                              MouseDoubleClick="lvi_MouseDoubleClick" SelectionChanged="lvSavedBuilds_SelectionChanged">
+                              MouseDoubleClick="lvi_MouseDoubleClick" SelectionChanged="lvSavedBuilds_SelectionChanged" Grid.RowSpan="2"
+                              SelectedIndex="{Binding ElementName=window,Path=PersistentData.Options.SelectedBuildIndex}">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <Grid Margin="1" MouseRightButtonUp="lvi_MouseRightButtonUp" MouseEnter="lvi_MouseEnter" MouseLeave="lvi_MouseLeave">
@@ -334,9 +343,17 @@
                             </DataTemplate>
                         </ListView.ItemTemplate>
                     </ListView>
-                    <Button x:Name="btnSaveNewBuild" Content="Save new" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Bottom" Width="80" Click="btnSaveNewBuild_Click"/>
-                    <Button x:Name="btnOverwriteBuild" Content="Overwrite" Margin="88,0,0,0" VerticalAlignment="Bottom" Click="btnOverwriteBuild_Click" HorizontalAlignment="Left" Width="84"/>
-                    <Button x:Name="btnDelete" Content="Delete" Margin="0,0,0,0" VerticalAlignment="Bottom" Click="btnDelete_Click" HorizontalAlignment="Right" Width="60"/>
+                    <CheckBox Grid.Row="1" Margin="2" IsChecked="{Binding IsChecked,ElementName=mnuViewComparison}">Tree comparison</CheckBox>
+                    <Grid Grid.Row="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="85"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="60"/>
+                        </Grid.ColumnDefinitions>
+                        <Button x:Name="btnSaveNewBuild" Content="Save new" HorizontalAlignment="Left" VerticalAlignment="Bottom" Width="80" Click="btnSaveNewBuild_Click"/>
+                        <Button x:Name="btnOverwriteBuild" Content="Overwrite" VerticalAlignment="Bottom" Click="btnOverwriteBuild_Click" HorizontalAlignment="Left" Width="84" Grid.Column="1"/>
+                        <Button x:Name="btnDelete" Content="Delete" VerticalAlignment="Bottom" Click="btnDelete_Click" HorizontalAlignment="Right" Width="60" Grid.Column="2"/>
+                    </Grid>
                 </Grid>
             </Expander>
 
@@ -352,7 +369,7 @@
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
                                             <ContentControl Content="{Binding Converter={StaticResource attributeToTextblockConverter}}"/>
-                                        </DataTemplate> 
+                                        </DataTemplate>
                                     </ListBox.ItemTemplate>
                                     <ListBox.GroupStyle>
                                         <GroupStyle ContainerStyle="{StaticResource ContainerStyleIsExpanded}" />

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -5,12 +5,15 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:POESKillTree.Controls"
+        xmlns:conv ="clr-namespace:POESKillTree.ViewModels"
         mc:Ignorable="d" x:Class="POESKillTree.Views.MainWindow"
         Title="Path of Exile - Passive Skill Tree Planner" Height="667" Width="1200" SizeChanged="Window_SizeChanged" 
         Closing="Window_Closing" Icon="/POESKillTree;component/logo.ico" Loaded="Window_Loaded" WindowStartupLocation="CenterScreen"
         PreviewKeyDown="Window_PreviewKeyDown"
         TextOptions.TextFormattingMode="Display">
     <Window.Resources>
+        <conv:SignConverter x:Key="signConverter" />
+        <conv:ArrayToVisibilityConverter x:Key="arrayToVisibilityConverter" />
         <Style x:Key="ContainerStyleIsExpanded" TargetType="{x:Type GroupItem}">
             <Setter Property="Template">
                 <Setter.Value>
@@ -312,7 +315,7 @@
                     <ListView x:Name="lvSavedBuilds" Margin="0,0,0,31" HorizontalAlignment="Left" Width="255"
                               ForceCursor="True" KeyUp="lvSavedBuilds_KeyUp" IsSynchronizedWithCurrentItem="True" BorderThickness="0"
                               AllowDrop="True" DragEnter="ListViewDragEnter" Drop="ListViewDrop" PreviewMouseMove="ListViewPreviewMouseMove" PreviewMouseLeftButtonDown="ListViewMouseLeftButtonDown"
-                              MouseDoubleClick="lvi_MouseDoubleClick">
+                              MouseDoubleClick="lvi_MouseDoubleClick" SelectionChanged="lvSavedBuilds_SelectionChanged">
                         <ListView.ItemTemplate>
                             <DataTemplate>
                                 <Grid Margin="1" MouseRightButtonUp="lvi_MouseRightButtonUp" MouseEnter="lvi_MouseEnter" MouseLeave="lvi_MouseLeave">
@@ -348,7 +351,24 @@
                                 <ListBox ScrollViewer.CanContentScroll="False" Height="{Binding ActualHeight, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type Grid}}}" HorizontalAlignment="Center" x:Name="listBox1" VerticalAlignment="Top" Width="{Binding ActualWidth, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type Grid}}}" ItemsSource="{Binding}" ScrollViewer.HorizontalScrollBarVisibility="Hidden" >
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <TextBlock Text="{Binding Text}" TextWrapping="Wrap" MouseRightButtonUp="TextBlock_MouseRightButtonUp"/>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Text}" TextWrapping="Wrap" MouseRightButtonUp="TextBlock_MouseRightButtonUp"/>
+                                                <StackPanel Orientation="Horizontal" Visibility="{Binding Deltas, Converter={StaticResource arrayToVisibilityConverter}}">
+                                                    <TextBlock Text=" "/>
+                                                    <ItemsControl ItemsSource="{Binding Deltas}">
+                                                        <ItemsControl.ItemsPanel>
+                                                            <ItemsPanelTemplate>
+                                                                <StackPanel Orientation="Horizontal"/>
+                                                            </ItemsPanelTemplate>
+                                                        </ItemsControl.ItemsPanel>
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <TextBlock Text="{Binding StringFormat=+#;-#;0}" Foreground="{Binding Converter={StaticResource signConverter}}"/>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                    </ItemsControl>
+                                                </StackPanel>
+                                            </StackPanel>
                                         </DataTemplate>
                                     </ListBox.ItemTemplate>
                                     <ListBox.GroupStyle>

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -12,8 +12,8 @@
         PreviewKeyDown="Window_PreviewKeyDown"
         TextOptions.TextFormattingMode="Display">
     <Window.Resources>
-        <conv:SignConverter x:Key="signConverter" />
-        <conv:ArrayToVisibilityConverter x:Key="arrayToVisibilityConverter" />
+        <conv:AttributeToTextblockConverter x:Key="attributeToTextblockConverter" />
+        
         <Style x:Key="ContainerStyleIsExpanded" TargetType="{x:Type GroupItem}">
             <Setter Property="Template">
                 <Setter.Value>
@@ -351,29 +351,7 @@
                                 <ListBox ScrollViewer.CanContentScroll="False" Height="{Binding ActualHeight, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type Grid}}}" HorizontalAlignment="Center" x:Name="listBox1" VerticalAlignment="Top" Width="{Binding ActualWidth, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type Grid}}}" ItemsSource="{Binding}" ScrollViewer.HorizontalScrollBarVisibility="Hidden" >
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock x:Name="pasiveAttributeText" Text="{Binding Text}" TextWrapping="Wrap" MouseRightButtonUp="TextBlock_MouseRightButtonUp"/>
-                                                <StackPanel Orientation="Horizontal" Visibility="{Binding Deltas, Converter={StaticResource arrayToVisibilityConverter}}">
-                                                    <TextBlock Text=" "/>
-                                                    <ItemsControl ItemsSource="{Binding Deltas}">
-                                                        <ItemsControl.ItemsPanel>
-                                                            <ItemsPanelTemplate>
-                                                                <StackPanel Orientation="Horizontal"/>
-                                                            </ItemsPanelTemplate>
-                                                        </ItemsControl.ItemsPanel>
-                                                        <ItemsControl.ItemTemplate>
-                                                            <DataTemplate>
-                                                                <TextBlock Text="{Binding StringFormat=+#;-#;0}" Foreground="{Binding Converter={StaticResource signConverter}}"/>
-                                                            </DataTemplate>
-                                                        </ItemsControl.ItemTemplate>
-                                                    </ItemsControl>
-                                                </StackPanel>
-                                            </StackPanel>
-                                            <DataTemplate.Triggers>
-                                                <DataTrigger Binding="{Binding Missing}" Value="true">
-                                                    <Setter TargetName="pasiveAttributeText" Property="Foreground" Value="Red"></Setter>
-                                                </DataTrigger>
-                                            </DataTemplate.Triggers>
+                                            <ContentControl Content="{Binding Converter={StaticResource attributeToTextblockConverter}}"/>
                                         </DataTemplate> 
                                     </ListBox.ItemTemplate>
                                     <ListBox.GroupStyle>

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -352,7 +352,7 @@
                                     <ListBox.ItemTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="{Binding Text}" TextWrapping="Wrap" MouseRightButtonUp="TextBlock_MouseRightButtonUp"/>
+                                                <TextBlock x:Name="pasiveAttributeText" Text="{Binding Text}" TextWrapping="Wrap" MouseRightButtonUp="TextBlock_MouseRightButtonUp"/>
                                                 <StackPanel Orientation="Horizontal" Visibility="{Binding Deltas, Converter={StaticResource arrayToVisibilityConverter}}">
                                                     <TextBlock Text=" "/>
                                                     <ItemsControl ItemsSource="{Binding Deltas}">
@@ -369,7 +369,12 @@
                                                     </ItemsControl>
                                                 </StackPanel>
                                             </StackPanel>
-                                        </DataTemplate>
+                                            <DataTemplate.Triggers>
+                                                <DataTrigger Binding="{Binding Missing}" Value="true">
+                                                    <Setter TargetName="pasiveAttributeText" Property="Foreground" Value="Red"></Setter>
+                                                </DataTrigger>
+                                            </DataTemplate.Triggers>
+                                        </DataTemplate> 
                                     </ListBox.ItemTemplate>
                                     <ListBox.GroupStyle>
                                         <GroupStyle ContainerStyle="{StaticResource ContainerStyleIsExpanded}" />

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -127,17 +127,17 @@ namespace POESKillTree.Views
             SetAccent(_persistentData.Options.Accent);
 
             Tree = SkillTree.CreateSkillTree(StartLoadingWindow, UpdateLoadingWindow, CloseLoadingWindow);
-            recSkillTree.Width = Tree.TRect.Width/Tree.TRect.Height*500;
+            recSkillTree.Width = SkillTree.TRect.Width / SkillTree.TRect.Height * 500;
             recSkillTree.UpdateLayout();
             recSkillTree.Fill = new VisualBrush(Tree.SkillTreeVisual);
 
             Tree.Chartype =
-                Tree.CharName.IndexOf(((string) ((ComboBoxItem) cbCharType.SelectedItem).Content).ToUpper());
+                SkillTree.CharName.IndexOf(((string)((ComboBoxItem)cbCharType.SelectedItem).Content).ToUpper());
             Tree.UpdateAvailNodes();
             UpdateAllAttributeList();
 
-            _multransform = Tree.TRect.Size/new Vector2D(recSkillTree.RenderSize.Width, recSkillTree.RenderSize.Height);
-            _addtransform = Tree.TRect.TopLeft;
+            _multransform = SkillTree.TRect.Size / new Vector2D(recSkillTree.RenderSize.Width, recSkillTree.RenderSize.Height);
+            _addtransform = SkillTree.TRect.TopLeft;
 
             expAttributes.IsExpanded = _persistentData.Options.AttributesBarOpened;
             expSavedBuilds.IsExpanded = _persistentData.Options.BuildsBarOpened;
@@ -562,11 +562,11 @@ namespace POESKillTree.Views
             else
             {
                 var startnode =
-                    Tree.Skillnodes.First(
-                        nd => nd.Value.Name.ToUpper() == (Tree.CharName[cbCharType.SelectedIndex]).ToUpper()).Value;
+                    SkillTree.Skillnodes.First(
+                        nd => nd.Value.Name.ToUpper() == (SkillTree.CharName[cbCharType.SelectedIndex]).ToUpper()).Value;
                 Tree.SkilledNodes.Clear();
                 Tree.SkilledNodes.Add(startnode.Id);
-                Tree.Chartype = Tree.CharName.IndexOf((Tree.CharName[cbCharType.SelectedIndex]).ToUpper());
+                Tree.Chartype = SkillTree.CharName.IndexOf((SkillTree.CharName[cbCharType.SelectedIndex]).ToUpper());
             }
             Tree.UpdateAvailNodes();
             UpdateAllAttributeList();
@@ -616,7 +616,7 @@ namespace POESKillTree.Views
                     }
                 }
 
-                foreach (var a in Tree.ImplicitAttributes(attritemp))
+                foreach (var a in SkillTree.ImplicitAttributes(attritemp,Tree.Level))
                 {
                     string key = SkillTree.RenameImplicitAttributes.ContainsKey(a.Key)
                         ? SkillTree.RenameImplicitAttributes[a.Key]
@@ -828,7 +828,7 @@ namespace POESKillTree.Views
             v = v*_multransform + _addtransform;
 
             IEnumerable<KeyValuePair<ushort, SkillNode>> nodes =
-                Tree.Skillnodes.Where(n => ((n.Value.Position - v).Length < 50)).ToList();
+                SkillTree.Skillnodes.Where(n => ((n.Value.Position - v).Length < 50)).ToList();
             if (nodes.Count() != 0)
             {
                 var node = nodes.First().Value;
@@ -879,7 +879,7 @@ namespace POESKillTree.Views
             SkillNode node = null;
 
             IEnumerable<KeyValuePair<ushort, SkillNode>> nodes =
-                Tree.Skillnodes.Where(n => ((n.Value.Position - v).Length < 50)).ToList();
+                SkillTree.Skillnodes.Where(n => ((n.Value.Position - v).Length < 50)).ToList();
             if (nodes.Count() != 0)
                 node = nodes.First().Value;
 
@@ -1693,12 +1693,14 @@ namespace POESKillTree.Views
             var list = sender as ListView;
             if (list != null && list.SelectedItem is PoEBuild)
             {
-                var tree2 = SkillTree.CreateSkillTree();
-                tree2.LoadFromURL(((PoEBuild)list.SelectedItem).Url);
+                var build = (PoEBuild)list.SelectedItem;
+                HashSet<ushort> nodes;
+                int ctype;
+                SkillTree.DecodeURL(build.Url,out nodes, out ctype);
 
-                Tree.HighlightedNodes = tree2.SkilledNodes;
+                Tree.HighlightedNodes = nodes;
 
-                Tree.HighlightedAttributes = tree2.SelectedAttributes;
+                Tree.HighlightedAttributes = SkillTree.GetAttributes(nodes,ctype,int.Parse(build.Level));
                 Tree.DrawNodeBaseSurroundHighlight();
                 UpdateAttributeList();
             }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -652,11 +652,34 @@ namespace POESKillTree.Views
         public void UpdateAttributeList()
         {
             _attiblist.Clear();
-            foreach (var item in (Tree.SelectedAttributes.Select(InsertNumbersInAttributes)))
+            Dictionary<string, List<float>> copy = (Tree.HighlightedAttributes == null)?null:new Dictionary<string, List<float>>(Tree.HighlightedAttributes);
+            
+            foreach (var item in Tree.SelectedAttributes)
             {
-                var a = new Attribute(item);
+                var a = new Attribute(InsertNumbersInAttributes(item));
+                if (copy!=null && copy.ContainsKey(item.Key))
+                {
+                    var citem = copy[item.Key];
+                    a.Deltas = item.Value.Zip(citem, (s, h) => s - h).ToArray();
+                    copy.Remove(item.Key);
+                }
+                else
+                {
+                    a.Deltas = (copy != null)?item.Value.ToArray():item.Value.Select(v=>0f).ToArray();
+                }
                 _attiblist.Add(a);
             }
+
+            if (copy != null)
+            {
+                foreach (var item in copy)
+                {
+                    var a = new Attribute(InsertNumbersInAttributes(new KeyValuePair<string, List<float>>(item.Key, item.Value.Select(v => 0f).ToList())));
+                    a.Deltas = item.Value.Select((h) => 0 - h).ToArray();
+                    _attiblist.Add(a);
+                }
+            }
+
             _attibuteCollection.Refresh();
             tbUsedPoints.Text = "" + (Tree.SkilledNodes.Count - 1);
         }
@@ -1661,6 +1684,22 @@ namespace POESKillTree.Views
         private void image1_LostFocus(object sender, MouseEventArgs e)
         {
             _sToolTip.IsOpen = false;
+        }
+
+        private void lvSavedBuilds_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var list = sender as ListView;
+            if (list != null && list.SelectedItem is PoEBuild)
+            {
+                var tree2 = SkillTree.CreateSkillTree();
+                tree2.LoadFromURL(((PoEBuild)list.SelectedItem).Url);
+
+                Tree.HighlightedNodes = tree2.SkilledNodes;
+
+                Tree.HighlightedAttributes = tree2.SelectedAttributes;
+                Tree.DrawNodeBaseSurroundHighlight();
+                UpdateAttributeList();
+            }
         }
     }
 }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -366,7 +366,7 @@ namespace POESKillTree.Views
 
                             SkillTree.ClearAssets();//enable recaching of assets
                             SkillTree.CreateSkillTree();//create new skilltree to reinitialize cache
-                            
+
 
                             btnLoadBuild_Click(this, new RoutedEventArgs());
                             _justLoaded = false;
@@ -432,7 +432,7 @@ namespace POESKillTree.Views
         }
 
         // Checks for updates.
-        private void  Menu_CheckForUpdates(object sender, RoutedEventArgs e)
+        private void Menu_CheckForUpdates(object sender, RoutedEventArgs e)
         {
             try
             {
@@ -621,7 +621,7 @@ namespace POESKillTree.Views
                     }
                 }
 
-                foreach (var a in SkillTree.ImplicitAttributes(attritemp,Tree.Level))
+                foreach (var a in SkillTree.ImplicitAttributes(attritemp, Tree.Level))
                 {
                     string key = SkillTree.RenameImplicitAttributes.ContainsKey(a.Key)
                         ? SkillTree.RenameImplicitAttributes[a.Key]
@@ -657,12 +657,12 @@ namespace POESKillTree.Views
         public void UpdateAttributeList()
         {
             _attiblist.Clear();
-            Dictionary<string, List<float>> copy = (Tree.HighlightedAttributes == null)?null:new Dictionary<string, List<float>>(Tree.HighlightedAttributes);
-            
+            Dictionary<string, List<float>> copy = (Tree.HighlightedAttributes == null) ? null : new Dictionary<string, List<float>>(Tree.HighlightedAttributes);
+
             foreach (var item in Tree.SelectedAttributes)
             {
                 var a = new Attribute(InsertNumbersInAttributes(item));
-                if (copy!=null && copy.ContainsKey(item.Key))
+                if (copy != null && copy.ContainsKey(item.Key))
                 {
                     var citem = copy[item.Key];
                     a.Deltas = item.Value.Zip(citem, (s, h) => s - h).ToArray();
@@ -670,7 +670,7 @@ namespace POESKillTree.Views
                 }
                 else
                 {
-                    a.Deltas = (copy != null)?item.Value.ToArray():item.Value.Select(v=>0f).ToArray();
+                    a.Deltas = (copy != null) ? item.Value.ToArray() : item.Value.Select(v => 0f).ToArray();
                 }
                 _attiblist.Add(a);
             }
@@ -827,10 +827,10 @@ namespace POESKillTree.Views
 
         private void zbSkillTreeBackground_Click(object sender, RoutedEventArgs e)
         {
-            Point p = ((MouseEventArgs) e.OriginalSource).GetPosition(zbSkillTreeBackground.Child);
+            Point p = ((MouseEventArgs)e.OriginalSource).GetPosition(zbSkillTreeBackground.Child);
             var v = new Vector2D(p.X, p.Y);
 
-            v = v*_multransform + _addtransform;
+            v = v * _multransform + _addtransform;
 
             IEnumerable<KeyValuePair<ushort, SkillNode>> nodes =
                 SkillTree.Skillnodes.Where(n => ((n.Value.Position - v).Length < 50)).ToList();
@@ -878,7 +878,7 @@ namespace POESKillTree.Views
         {
             Point p = e.GetPosition(zbSkillTreeBackground.Child);
             var v = new Vector2D(p.X, p.Y);
-            v = v*_multransform + _addtransform;
+            v = v * _multransform + _addtransform;
             textBox1.Text = "" + v.X;
             textBox2.Text = "" + v.Y;
             SkillNode node = null;
@@ -1237,7 +1237,7 @@ namespace POESKillTree.Views
         private void BeginDrag(MouseEventArgs e)
         {
             var listView = lvSavedBuilds;
-            var listViewItem = FindAnchestor<ListViewItem>((DependencyObject) e.OriginalSource);
+            var listViewItem = FindAnchestor<ListViewItem>((DependencyObject)e.OriginalSource);
 
             if (listViewItem == null)
                 return;
@@ -1309,7 +1309,7 @@ namespace POESKillTree.Views
         private void InitialiseAdorner(UIElement listViewItem)
         {
             var brush = new VisualBrush(listViewItem);
-            _adorner = new DragAdorner(listViewItem, listViewItem.RenderSize, brush) {Opacity = 0.5};
+            _adorner = new DragAdorner(listViewItem, listViewItem.RenderSize, brush) { Opacity = 0.5 };
             _layer = AdornerLayer.GetAdornerLayer(lvSavedBuilds);
             _layer.Add(_adorner);
         }
@@ -1631,7 +1631,7 @@ namespace POESKillTree.Views
                 return array;
             }
         }
-        #endregion  
+        #endregion
 
         #region Legacy
 
@@ -1705,7 +1705,7 @@ namespace POESKillTree.Views
 
                 Tree.HighlightedNodes = nodes;
                 Tree.HighlightedAttributes = SkillTree.GetAttributes(nodes, ctype, int.Parse(build.Level));
-                
+
             }
             else
             {

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -1701,14 +1701,20 @@ namespace POESKillTree.Views
                 var build = (PoEBuild)list.SelectedItem;
                 HashSet<ushort> nodes;
                 int ctype;
-                SkillTree.DecodeURL(build.Url,out nodes, out ctype);
+                SkillTree.DecodeURL(build.Url, out nodes, out ctype);
 
                 Tree.HighlightedNodes = nodes;
-
-                Tree.HighlightedAttributes = SkillTree.GetAttributes(nodes,ctype,int.Parse(build.Level));
-                Tree.DrawNodeBaseSurroundHighlight();
-                UpdateAttributeList();
+                Tree.HighlightedAttributes = SkillTree.GetAttributes(nodes, ctype, int.Parse(build.Level));
+                
             }
+            else
+            {
+                Tree.HighlightedNodes = null;
+                Tree.HighlightedAttributes = null;
+            }
+
+            Tree.DrawNodeBaseSurroundHighlight();
+            UpdateAttributeList();
         }
     }
 }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -681,8 +681,8 @@ namespace POESKillTree.Views
                 {
                     var a = new Attribute(InsertNumbersInAttributes(new KeyValuePair<string, List<float>>(item.Key, item.Value.Select(v => 0f).ToList())));
                     a.Deltas = item.Value.Select((h) => 0 - h).ToArray();
-                    if(item.Value.Count == 0)
-                        a.Missing = true;
+                    // if(item.Value.Count == 0)
+                    a.Missing = true;
                     _attiblist.Add(a);
                 }
             }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -46,6 +46,13 @@ namespace POESKillTree.Views
     public partial class MainWindow : MetroWindow
     {
         private readonly PersistentData _persistentData = new PersistentData();
+
+        public PersistentData PersistentData
+        {
+            get { return _persistentData; }
+        } 
+
+
         private static readonly Action EmptyDelegate = delegate { };
         private readonly List<Attribute> _allAttributesList = new List<Attribute>();
         private readonly List<Attribute> _attiblist = new List<Attribute>();
@@ -1695,10 +1702,12 @@ namespace POESKillTree.Views
 
         private void lvSavedBuilds_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            var list = sender as ListView;
-            if (list != null && list.SelectedItem is PoEBuild)
+            if (Tree == null)
+                return;
+
+            if (lvSavedBuilds != null && lvSavedBuilds.SelectedItem is PoEBuild && _persistentData.Options.TreeComparisonEnabled)
             {
-                var build = (PoEBuild)list.SelectedItem;
+                var build = (PoEBuild)lvSavedBuilds.SelectedItem;
                 HashSet<ushort> nodes;
                 int ctype;
                 SkillTree.DecodeURL(build.Url, out nodes, out ctype);
@@ -1715,6 +1724,11 @@ namespace POESKillTree.Views
 
             Tree.DrawNodeBaseSurroundHighlight();
             UpdateAttributeList();
+        }
+
+        private void ToggleTreeComparison_Click(object sender, RoutedEventArgs e)
+        {
+            lvSavedBuilds_SelectionChanged(null, null);
         }
     }
 }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -676,6 +676,8 @@ namespace POESKillTree.Views
                 {
                     var a = new Attribute(InsertNumbersInAttributes(new KeyValuePair<string, List<float>>(item.Key, item.Value.Select(v => 0f).ToList())));
                     a.Deltas = item.Value.Select((h) => 0 - h).ToArray();
+                    if(item.Value.Count == 0)
+                        a.Missing = true;
                     _attiblist.Add(a);
                 }
             }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -363,6 +363,11 @@ namespace POESKillTree.Views
                             Tree = SkillTree.CreateSkillTree(StartLoadingWindow, UpdateLoadingWindow, CloseLoadingWindow);
                             recSkillTree.Fill = new VisualBrush(Tree.SkillTreeVisual);
 
+
+                            SkillTree.ClearAssets();//enable recaching of assets
+                            SkillTree.CreateSkillTree();//create new skilltree to reinitialize cache
+                            
+
                             btnLoadBuild_Click(this, new RoutedEventArgs());
                             _justLoaded = false;
 

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -173,6 +173,7 @@
     <Compile Include="ViewModels\ListGroupItem.cs" />
     <Compile Include="ViewModels\ItemAttribute\ItemMod.cs" />
     <Compile Include="ViewModels\MetroMessageBoxViewModel.cs" />
+    <Compile Include="ViewModels\Converters.cs" />
     <Compile Include="Views\HelpWindow.xaml.cs">
       <DependentUpon>HelpWindow.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
Selected build (in the saved builds expander) is highlighted (paths and passives) by the green color
Attributes in "PassiveAttributes" expander now shows difference to the selected build
  - attribute have bigger value than selected build: green colored "+number" at the end of attribute line
  - attribute have lesser value than selected build: red colored "-number" at the end of attribute line
  - attribute have same value as selected build: nothing :)

Passive attributes in the selected build that are missing from the current build are automatically added with value 0

![poeskilltreecomparison](https://cloud.githubusercontent.com/assets/2779184/5621308/9671b718-9534-11e4-8177-fab0ff39f2a9.png)

solution for issue #70, maybe :)