### PR TITLE
Added application controlled pinning on taskbar

### DIFF
--- a/WPFSKillTree/Locale/Messages.pot
+++ b/WPFSKillTree/Locale/Messages.pot
@@ -478,6 +478,10 @@ msgstr ""
 msgid "Download completed or still in progress"
 msgstr ""
 
+#: Utils\TaskbarHelper.cs:79
+msgid "Pin this program to taskbar"
+msgstr ""
+
 #: ViewModels\PoEBuild.cs:30
 #, csharp-format
 msgid "{0}, {1} point used"
@@ -506,49 +510,49 @@ msgstr ""
 msgid "Help file not found"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:462
+#: Views\MainWindow.xaml.cs:464
 msgid "You have the latest version!"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:462
+#: Views\MainWindow.xaml.cs:464
 msgid "No update"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:466
+#: Views\MainWindow.xaml.cs:468
 #, csharp-format
 msgid "Do you want to install version {0}?"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:470
+#: Views\MainWindow.xaml.cs:472
 msgid "This is a pre-release, meaning there could be some bugs!"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:471
+#: Views\MainWindow.xaml.cs:473
 msgid "New pre-release"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:474
+#: Views\MainWindow.xaml.cs:476
 msgid "New release"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:486
+#: Views\MainWindow.xaml.cs:488
 msgid "Error occured"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:503 Views\MainWindow.xaml.cs:530
-#: Views\MainWindow.xaml.cs:543
+#: Views\MainWindow.xaml.cs:505 Views\MainWindow.xaml.cs:532
+#: Views\MainWindow.xaml.cs:545
 msgid "Update failed"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:1072
+#: Views\MainWindow.xaml.cs:1074
 msgid "Right click to edit"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:1143
+#: Views\MainWindow.xaml.cs:1145
 msgid "Please select a saved build!"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:1143
+#: Views\MainWindow.xaml.cs:1145
 msgid "Error"
 msgstr ""
 

--- a/WPFSKillTree/Locale/sk/Messages.po
+++ b/WPFSKillTree/Locale/sk/Messages.po
@@ -478,6 +478,10 @@ msgstr "Súbor alebo priečinok nebol nájdený: {0}"
 msgid "Download completed or still in progress"
 msgstr "Sťahovanie bolo donočené, alebo stále prebieha"
 
+#: Utils\TaskbarHelper.cs:79
+msgid "Pin this program to taskbar"
+msgstr "Pripnúť tento program na panel úloh"
+
 #: ViewModels\PoEBuild.cs:30
 #, csharp-format
 msgid "{0}, {1} point used"
@@ -507,49 +511,49 @@ msgstr "Posledná zmena: {0}"
 msgid "Help file not found"
 msgstr "Súbor pomocníka nebol nájdený"
 
-#: Views\MainWindow.xaml.cs:462
+#: Views\MainWindow.xaml.cs:464
 msgid "You have the latest version!"
 msgstr "Máte najnovšiu verziu!"
 
-#: Views\MainWindow.xaml.cs:462
+#: Views\MainWindow.xaml.cs:464
 msgid "No update"
 msgstr "Žiadna aktualizácia"
 
-#: Views\MainWindow.xaml.cs:466
+#: Views\MainWindow.xaml.cs:468
 #, csharp-format
 msgid "Do you want to install version {0}?"
 msgstr "Chcete nainštalovať verziu {0}?"
 
-#: Views\MainWindow.xaml.cs:470
+#: Views\MainWindow.xaml.cs:472
 msgid "This is a pre-release, meaning there could be some bugs!"
 msgstr "Toto je predbežná verzia, ktorá môže obsahovať chyby!"
 
-#: Views\MainWindow.xaml.cs:471
+#: Views\MainWindow.xaml.cs:473
 msgid "New pre-release"
 msgstr "Nová predbežná verzia"
 
-#: Views\MainWindow.xaml.cs:474
+#: Views\MainWindow.xaml.cs:476
 msgid "New release"
 msgstr "Nová verzia"
 
-#: Views\MainWindow.xaml.cs:486
+#: Views\MainWindow.xaml.cs:488
 msgid "Error occured"
 msgstr "Nastala chyba"
 
-#: Views\MainWindow.xaml.cs:503 Views\MainWindow.xaml.cs:530
-#: Views\MainWindow.xaml.cs:543
+#: Views\MainWindow.xaml.cs:505 Views\MainWindow.xaml.cs:532
+#: Views\MainWindow.xaml.cs:545
 msgid "Update failed"
 msgstr "Aktualizácia zlyhala"
 
-#: Views\MainWindow.xaml.cs:1072
+#: Views\MainWindow.xaml.cs:1074
 msgid "Right click to edit"
 msgstr "Upraviť kliknutím pravého tlačidla"
 
-#: Views\MainWindow.xaml.cs:1143
+#: Views\MainWindow.xaml.cs:1145
 msgid "Please select a saved build!"
 msgstr "Prosím zvoľte uloženú zostavu!"
 
-#: Views\MainWindow.xaml.cs:1143
+#: Views\MainWindow.xaml.cs:1145
 msgid "Error"
 msgstr "Chyba"
 

--- a/WPFSKillTree/SkillTreeFiles/Bootstrap.cs
+++ b/WPFSKillTree/SkillTreeFiles/Bootstrap.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Windows;
+using POESKillTree.Utils;
 using POESKillTree.Views;
 using Microsoft.WindowsAPICodePack.Shell;
 using Microsoft.WindowsAPICodePack.Taskbar;
@@ -76,6 +77,10 @@ namespace POESKillTree.SkillTreeFiles
         [STAThread]
         public static void Main(string[] arguments)
         {
+            // If executed from JumpTask, do nothing.
+            if (TaskbarHelper.IsJumpTask(arguments))
+                return;
+
             // Don't do shadow copying when being debugged in VS.
             if (Debugger.IsAttached)
             {

--- a/WPFSKillTree/Utils/TaskbarHelper.cs
+++ b/WPFSKillTree/Utils/TaskbarHelper.cs
@@ -154,9 +154,7 @@ namespace POESKillTree.Utils
         {
             get
             {
-                if (HasVerbsLoaded) return HasVerbsLoaded;
-
-                LoadVerbs();
+                if (!HasVerbsLoaded) LoadVerbs();
 
                 return HasPinningVerbs;
             }

--- a/WPFSKillTree/Utils/TaskbarHelper.cs
+++ b/WPFSKillTree/Utils/TaskbarHelper.cs
@@ -60,7 +60,7 @@ namespace POESKillTree.Utils
             // No pinning when debugging.
             if (Debugger.IsAttached) return;
 
-            if (!IsPinned)
+            if (IsPinningSupported && !IsPinned)
             {
                 // Prevent window from getting pinned by OS.
                 WindowProperties.SetWindowProperty(window, SystemProperties.System.AppUserModel.PreventPinning, "true");

--- a/WPFSKillTree/Utils/TaskbarHelper.cs
+++ b/WPFSKillTree/Utils/TaskbarHelper.cs
@@ -1,0 +1,296 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Shell;
+using Microsoft.WindowsAPICodePack.Shell.PropertySystem;
+using POESKillTree.Localization;
+
+namespace POESKillTree.Utils
+{
+    // Taskbar helper class.
+    class TaskbarHelper
+    {
+        #region Interop
+
+        // Interop declaration for KERNEL32.DLL FreeLibrary function.
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool FreeLibrary(IntPtr hModule);
+        // Interop declaration for KERNEL32.DLL LoadLibrary function.
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Ansi)]
+        static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)]string lpFileName);
+        // Interop declaration for USER32.DLL LoadString function.
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        static extern int LoadString(IntPtr hInstance, uint uID, StringBuilder lpBuffer, int nBufferMax);
+        // Interop declaration for USER32.DLL SendMessage function.
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        static extern IntPtr SendMessage(IntPtr hWnd, UInt32 Msg, IntPtr wParam, IntPtr lParam);
+
+        #endregion
+
+        // String resource identifiers of FolderItemVerbs in Shell32 DLL.
+        enum Shell32VerbID
+        {
+            PinToTaskbar = 5386,
+            UnpinFromTaskbar = 5387
+        }
+
+        // The argument used by pinning JumpTask.
+        const string JumpTaskPinningArgument = "/P";
+        // Window message for pinning JumpTask (WM_APP + 1).
+        const uint WM_PINNING = 0x8000 + 1;
+
+        // The flag whether all pinning Verbs were retrieved.
+        static bool HasPinningVerbs = false;
+        // The flag whether Verb retrieval was attempted.
+        static bool HasVerbsLoaded = false;
+        // Localized "Pin to Taskbar" Verb.
+        static string PinToTaskbarVerb;
+        // Localized "Unpin from Taskbar" Verb.
+        static string UnpinFromTaskbarVerb;
+
+        // Enables custom pinning.
+        public static void EnablePinning(Window window)
+        {
+            // No pinning when debugging.
+            if (Debugger.IsAttached) return;
+
+            if (!IsPinned)
+            {
+                // Prevent window from getting pinned by OS.
+                WindowProperties.SetWindowProperty(window, SystemProperties.System.AppUserModel.PreventPinning, "true");
+
+                JumpList jumpList = JumpList.GetJumpList(Application.Current);
+                if (jumpList != null)
+                {
+                    string exePath = GetOriginalExeLocation();
+
+                    JumpTask jumpTask = new JumpTask();
+                    jumpTask.ApplicationPath = exePath;
+                    jumpTask.WorkingDirectory = Path.GetDirectoryName(exePath);
+                    jumpTask.IconResourcePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "imageres.dll");
+                    jumpTask.IconResourceIndex = 217; // Pin
+                    jumpTask.Arguments = JumpTaskPinningArgument;
+                    jumpTask.Title = L10n.Message("Pin this program to taskbar");
+                    jumpList.JumpItems.Add(jumpTask);
+
+                    jumpList.Apply();
+                }
+
+                // Register window message processing hook for main application window.
+                HwndSource source = HwndSource.FromHwnd(new WindowInteropHelper(window).Handle);
+                source.AddHook(new HwndSourceHook(WndProc));
+            }
+        }
+
+        // Returns location of original executable.
+        static string GetOriginalExeLocation()
+        {
+            Assembly assembly = Assembly.GetExecutingAssembly();
+
+            string dir = Path.GetDirectoryName(new Uri(assembly.GetName().EscapedCodeBase).LocalPath);
+
+            // Filename part must be from assembly location's filename (assembly CodeBase has mangled filename extension).
+            return Path.Combine(dir, Path.GetFileName(assembly.Location));
+        }
+
+        // Returns true if execution was trigger from JumpTask.
+        public static bool IsJumpTask(string[] arguments)
+        {
+            // Pinning requested (executed from JumpTask).
+            if (arguments.Length == 1 && arguments[0] == JumpTaskPinningArgument)
+            {
+                // No pinning when debugging.
+                if (Debugger.IsAttached) return true;
+
+                NotifyApplication(WM_PINNING);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        // Returns true if executable is pinned.
+        static bool IsPinned
+        {
+            get
+            {
+                if (!IsPinningSupported) return false;
+
+                dynamic application = Activator.CreateInstance(Type.GetTypeFromProgID("Shell.Application"));
+
+                string path = GetOriginalExeLocation();
+                string dirName = Path.GetDirectoryName(path);
+                string fileName = Path.GetFileName(path);
+
+                dynamic directory = application.NameSpace(dirName);
+                dynamic link = directory.ParseName(fileName);
+                dynamic verbs = link.Verbs();
+
+                for (int i = 0; i < verbs.Count(); i++)
+                {
+                    dynamic verb = verbs.Item(i);
+                    string verbName = verb.Name;
+
+                    if (verbName == UnpinFromTaskbarVerb)
+                        return true;
+                    else
+                        if (verbName == PinToTaskbarVerb)
+                            return false;
+                }
+
+                return false;
+            }
+        }
+
+        // Returns true if OS version supports taskbar pinning.
+        static bool IsPinningSupported
+        {
+            get
+            {
+                if (HasVerbsLoaded) return HasVerbsLoaded;
+
+                LoadVerbs();
+
+                return HasPinningVerbs;
+            }
+        }
+
+        // Loads localized Verbs from Shell32 DLL.
+        static void LoadVerbs()
+        {
+            // Don't attempt to load Verbs again.
+            if (HasVerbsLoaded) return;
+            HasVerbsLoaded = true;
+
+            StringBuilder sb = new StringBuilder(255);
+
+            IntPtr handle = LoadLibrary("shell32.dll");
+            if (handle == IntPtr.Zero) return;
+
+            int loaded = LoadString(handle, (uint)Shell32VerbID.PinToTaskbar, sb, sb.Capacity + 1);
+            if (loaded > 0 && loaded < sb.Capacity)
+                PinToTaskbarVerb = sb.ToString();
+            sb.Clear();
+
+            LoadString(handle, (uint)Shell32VerbID.UnpinFromTaskbar, sb, sb.Capacity + 1);
+            if (loaded > 0 && loaded < sb.Capacity)
+                UnpinFromTaskbarVerb = sb.ToString();
+            sb.Clear();
+
+            HasPinningVerbs = !string.IsNullOrEmpty(PinToTaskbarVerb) && !string.IsNullOrEmpty(UnpinFromTaskbarVerb);
+
+            FreeLibrary(handle);
+        }
+
+        // Notifies application.
+        static void NotifyApplication(uint wm)
+        {
+            // Get current PID to exclude from running process.
+            int pid = Process.GetCurrentProcess().Id;
+
+            Process[] ps = Process.GetProcessesByName(Process.GetCurrentProcess().ProcessName);
+            for (int i = 0; i < ps.Length; ++i)
+            {
+                if (ps[i].Id == pid) continue;
+
+                IntPtr handle = ps[i].MainWindowHandle;
+                if (handle != IntPtr.Zero)
+                {
+                    // Send message to window.
+                    SendMessage(handle, wm, IntPtr.Zero, IntPtr.Zero);
+                }
+            }
+        }
+
+        // Pins executable to taskbar.
+        static void PinToTaskbar()
+        {
+            if (!IsPinningSupported) throw new NotSupportedException("Taskbar pinning not supported");
+
+            dynamic application = Activator.CreateInstance(Type.GetTypeFromProgID("Shell.Application"));
+
+            string path = GetOriginalExeLocation();
+            string dirName = Path.GetDirectoryName(path);
+            string fileName = Path.GetFileName(path);
+
+            dynamic directory = application.NameSpace(dirName);
+            dynamic link = directory.ParseName(fileName);
+            dynamic verbs = link.Verbs();
+
+            for (int i = 0; i < verbs.Count(); i++)
+            {
+                dynamic verb = verbs.Item(i);
+                string verbName = verb.Name;
+
+                if (verbName == PinToTaskbarVerb)
+                {
+                    verb.DoIt();
+
+                    return;
+                }
+            }
+        }
+
+        // Removes pinning JumpTask.
+        static void RemoveJumpTask()
+        {
+            JumpList jumpList = JumpList.GetJumpList(Application.Current);
+            if (jumpList != null && jumpList.JumpItems.Count == 1)
+            {
+                jumpList.JumpItems.Clear();
+                jumpList.Apply();
+            }
+        }
+
+        // Unpins executable from taskbar.
+        static void UnpinFromTaskbar()
+        {
+            if (!IsPinningSupported) throw new NotSupportedException("Taskbar pinning not supported");
+
+            dynamic application = Activator.CreateInstance(Type.GetTypeFromProgID("Shell.Application"));
+
+            string path = GetOriginalExeLocation();
+            string dirName = Path.GetDirectoryName(path);
+            string fileName = Path.GetFileName(path);
+
+            dynamic directory = application.NameSpace(dirName);
+            dynamic link = directory.ParseName(fileName);
+            dynamic verbs = link.Verbs();
+
+            for (int i = 0; i < verbs.Count(); i++)
+            {
+                dynamic verb = verbs.Item(i);
+                string verbName = verb.Name;
+
+                if (verbName == UnpinFromTaskbarVerb)
+                {
+                    verb.DoIt();
+
+                    return;
+                }
+            }
+        }
+
+        // Handles window message of application.
+        private static IntPtr WndProc(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == WM_PINNING)
+            {
+                handled = true;
+
+                if (!IsPinned) PinToTaskbar();
+
+                RemoveJumpTask();
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}

--- a/WPFSKillTree/Views/App.xaml
+++ b/WPFSKillTree/Views/App.xaml
@@ -17,4 +17,8 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>
+    <JumpList.JumpList>
+        <JumpList ShowFrequentCategory="False" ShowRecentCategory="False">
+        </JumpList>
+    </JumpList.JumpList>
 </Application>

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -103,6 +103,8 @@ namespace POESKillTree.Views
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {
+            TaskbarHelper.EnablePinning(this);
+
             ItemDB.Load("Items.xml");
             if (File.Exists("ItemsLocal.xml"))
                 ItemDB.Merge("ItemsLocal.xml");

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -182,6 +182,7 @@
     <Compile Include="SkillTreeFiles\SteinerTrees\Steiner.cs" />
     <Compile Include="SkillTreeFiles\SteinerTrees\WeightedSampling.cs" />
     <Compile Include="SkillTreeFiles\Updater.cs" />
+    <Compile Include="Utils\TaskbarHelper.cs" />
     <Compile Include="ViewModels\AttributeGroup.cs" />
     <Compile Include="ViewModels\ItemAttribute\Item.cs" />
     <Compile Include="ViewModels\ListGroup.cs" />


### PR DESCRIPTION
Added application controlled pinning on taskbar to avoid pinning of running shadow copy by OS.

This was longstanding issue with people pinning running shadow copy to taskbar instead of original executable by hand.

Found solution of using JumpTask to fake visual of pinning command and programatic way to perform "Pin to taskbar" operation, while having window flagged with PreventPinning, which disallows OS native "Pin this program blah blah" command.

All stuff is done in TaskbarHelper class, with almost no intrusion to rest of application.
Later it can be used for other fancy Windows 7+ stuff, like Recent builds jump lists, etc.