### PR TITLE
Fixed GetAppUserModelId returning incorrect identifier

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/Bootstrap.cs
+++ b/WPFSKillTree/SkillTreeFiles/Bootstrap.cs
@@ -48,7 +48,7 @@ namespace POESKillTree.SkillTreeFiles
 
                     // If location is inside of known folder, replace its path with GUID.
                     if (path.StartsWith(knownFolder.ParsingName))
-                        return Path.Combine("{" + knownFolder.FolderId.ToString().ToUpperInvariant() + "}", Path.GetFileName(location));
+                        return Path.Combine("{" + knownFolder.FolderId.ToString().ToUpperInvariant() + "}", location.Substring(knownFolder.ParsingName.Length + 1));
                 }
             }
 


### PR DESCRIPTION
Fixed GetAppUserModelId returning incorrect identifier for application in subfolder of known folder.