### PR TITLE
Fixed PersistenData being saved twice in Window_Closing method causin…

### DIFF
--- a/WPFSKillTree/Locale/Messages.pot
+++ b/WPFSKillTree/Locale/Messages.pot
@@ -600,6 +600,15 @@ msgid_plural "{0}, {1} points used"
 msgstr[0] ""
 msgstr[1] ""
 
+#: Views\App.xaml.cs:94 Views\MainWindow.xaml.cs:1233
+msgid "An error has occurred during a save operation:"
+msgstr ""
+
+#: Views\App.xaml.cs:94 Views\MainWindow.xaml.cs:1140
+#: Views\MainWindow.xaml.cs:1233
+msgid "Error"
+msgstr ""
+
 #: Views\DownloadItemsWindow.xaml.cs:25 Views\DownloadItemsWindow.xaml.cs:31
 msgid "CharacterName"
 msgstr ""
@@ -621,50 +630,46 @@ msgstr ""
 msgid "Help file not found"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:464
+#: Views\MainWindow.xaml.cs:459
 msgid "You have the latest version!"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:464
+#: Views\MainWindow.xaml.cs:459
 msgid "No update"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:468
+#: Views\MainWindow.xaml.cs:463
 #, csharp-format
 msgid "Do you want to install version {0}?"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:472
+#: Views\MainWindow.xaml.cs:467
 msgid "This is a pre-release, meaning there could be some bugs!"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:473
+#: Views\MainWindow.xaml.cs:468
 msgid "New pre-release"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:476
+#: Views\MainWindow.xaml.cs:471
 msgid "New release"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:487
+#: Views\MainWindow.xaml.cs:482
 msgid "Error occured"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:504 Views\MainWindow.xaml.cs:532
-#: Views\MainWindow.xaml.cs:546
+#: Views\MainWindow.xaml.cs:499 Views\MainWindow.xaml.cs:527
+#: Views\MainWindow.xaml.cs:541
 msgid "Update failed"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:1074
+#: Views\MainWindow.xaml.cs:1069
 msgid "Right click to edit"
 msgstr ""
 
-#: Views\MainWindow.xaml.cs:1145
+#: Views\MainWindow.xaml.cs:1140
 msgid "Please select a saved build!"
-msgstr ""
-
-#: Views\MainWindow.xaml.cs:1145
-msgid "Error"
 msgstr ""
 
 #: Views\OptimizerControllerWindow.xaml.cs:62

--- a/WPFSKillTree/Locale/sk/Messages.po
+++ b/WPFSKillTree/Locale/sk/Messages.po
@@ -601,6 +601,15 @@ msgstr[0] "{0}, {1} bod použitý"
 msgstr[1] "{0}, {1} body použité"
 msgstr[2] "{0}, {1} bodov použitých"
 
+#: Views\App.xaml.cs:94 Views\MainWindow.xaml.cs:1233
+msgid "An error has occurred during a save operation:"
+msgstr "Nastala chyba počas ukladania:"
+
+#: Views\App.xaml.cs:94 Views\MainWindow.xaml.cs:1140
+#: Views\MainWindow.xaml.cs:1233
+msgid "Error"
+msgstr "Chyba"
+
 #: Views\DownloadItemsWindow.xaml.cs:25 Views\DownloadItemsWindow.xaml.cs:31
 msgid "CharacterName"
 msgstr "MenoPostavy"
@@ -622,51 +631,47 @@ msgstr "Posledná zmena: {0}"
 msgid "Help file not found"
 msgstr "Súbor pomocníka nebol nájdený"
 
-#: Views\MainWindow.xaml.cs:464
+#: Views\MainWindow.xaml.cs:459
 msgid "You have the latest version!"
 msgstr "Máte najnovšiu verziu!"
 
-#: Views\MainWindow.xaml.cs:464
+#: Views\MainWindow.xaml.cs:459
 msgid "No update"
 msgstr "Žiadna aktualizácia"
 
-#: Views\MainWindow.xaml.cs:468
+#: Views\MainWindow.xaml.cs:463
 #, csharp-format
 msgid "Do you want to install version {0}?"
 msgstr "Chcete nainštalovať verziu {0}?"
 
-#: Views\MainWindow.xaml.cs:472
+#: Views\MainWindow.xaml.cs:467
 msgid "This is a pre-release, meaning there could be some bugs!"
 msgstr "Toto je predbežná verzia, ktorá môže obsahovať chyby!"
 
-#: Views\MainWindow.xaml.cs:473
+#: Views\MainWindow.xaml.cs:468
 msgid "New pre-release"
 msgstr "Nová predbežná verzia"
 
-#: Views\MainWindow.xaml.cs:476
+#: Views\MainWindow.xaml.cs:471
 msgid "New release"
 msgstr "Nová verzia"
 
-#: Views\MainWindow.xaml.cs:487
+#: Views\MainWindow.xaml.cs:482
 msgid "Error occured"
 msgstr "Nastala chyba"
 
-#: Views\MainWindow.xaml.cs:504 Views\MainWindow.xaml.cs:532
-#: Views\MainWindow.xaml.cs:546
+#: Views\MainWindow.xaml.cs:499 Views\MainWindow.xaml.cs:527
+#: Views\MainWindow.xaml.cs:541
 msgid "Update failed"
 msgstr "Aktualizácia zlyhala"
 
-#: Views\MainWindow.xaml.cs:1074
+#: Views\MainWindow.xaml.cs:1069
 msgid "Right click to edit"
 msgstr "Upraviť kliknutím pravého tlačidla"
 
-#: Views\MainWindow.xaml.cs:1145
+#: Views\MainWindow.xaml.cs:1140
 msgid "Please select a saved build!"
 msgstr "Prosím zvoľte uloženú zostavu!"
-
-#: Views\MainWindow.xaml.cs:1145
-msgid "Error"
-msgstr "Chyba"
 
 #: Views\OptimizerControllerWindow.xaml.cs:62
 msgid "Cancel"

--- a/WPFSKillTree/Model/PersistentData.cs
+++ b/WPFSKillTree/Model/PersistentData.cs
@@ -64,10 +64,9 @@ namespace POESKillTree.Model
             }
         }
 
-        public void SaveBuilds(ItemCollection items)
+        public void SetBuilds(ItemCollection items)
         {
             Builds = (from PoEBuild item in items select item).ToList();
-            SavePersistentDataToFile();
         }
 
         private void OnPropertyChanged(string caller)

--- a/WPFSKillTree/Views/App.xaml.cs
+++ b/WPFSKillTree/Views/App.xaml.cs
@@ -44,7 +44,14 @@ namespace POESKillTree.Views
             }
 
             // Load persistent data.
-            PrivatePersistentData.LoadPersistentDataFromFile();
+            try
+            {
+                PrivatePersistentData.LoadPersistentDataFromFile();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("An error has occurred during a load operation:\n\n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
 
             // Initialize localization.
             L10n.Initialize(PrivatePersistentData);
@@ -69,10 +76,25 @@ namespace POESKillTree.Views
                         theException = theException.InnerException;
                     }
                 }
-                MessageBox.Show("The program crashed.  A stack trace can be found at:\n" + theErrorPath);
+                MessageBox.Show("The program crashed. A stack trace can be found at:\n" + theErrorPath);
                 e.Handled = true;
                 Application.Current.Shutdown();
             }
+        }
+
+        // Overrides OnExit method to save persistent data.
+        protected override void OnExit(ExitEventArgs e)
+        {
+            try
+            {
+                PrivatePersistentData.SavePersistentDataToFile();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(L10n.Message("An error has occurred during a save operation:") + "\n\n" + ex.Message, L10n.Message("Error"), MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            base.OnExit(e);
         }
     }
 }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -233,12 +233,7 @@ namespace POESKillTree.Views
         {
             _persistentData.CurrentBuild.Url = tbSkillURL.Text;
             _persistentData.CurrentBuild.Level = tbLevel.Text;
-            _persistentData.SavePersistentDataToFile();
-
-            if (lvSavedBuilds.Items.Count > 0)
-            {
-                SaveBuildsToFile();
-            }
+            _persistentData.SetBuilds(lvSavedBuilds.Items);
         }
 
         #endregion
@@ -1228,7 +1223,15 @@ namespace POESKillTree.Views
 
         private void SaveBuildsToFile()
         {
-            _persistentData.SaveBuilds(lvSavedBuilds.Items);
+            try
+            {
+                _persistentData.SetBuilds(lvSavedBuilds.Items);
+                _persistentData.SavePersistentDataToFile();
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show(L10n.Message("An error has occurred during a save operation:") + "\n\n" + e.Message, L10n.Message("Error"), MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         private void LoadBuildFromUrl()


### PR DESCRIPTION
Fixed PersistenData being saved twice in Window_Closing method causing double-crash when exception occurs.
Added proper exception handling during SaveBuildsToFile method.

Fixes #102