### PR TITLE
Added Crossed HighlightState that is ignored by the skill tree optimizer

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
+++ b/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
@@ -16,6 +16,15 @@ namespace POESKillTree.SkillTreeFiles
 
         public Dictionary<SkillNode, HighlightState> nodeHighlights = new Dictionary<SkillNode, HighlightState>();
 
+        public bool NodeHasHighlights(SkillNode node, HighlightState flags)
+        {
+            if (nodeHighlights.ContainsKey(node))
+            {
+                return nodeHighlights[node].HasFlag(flags);
+            }
+            return false;
+        }
+
         public void ToggleHighlightNode(SkillNode node, HighlightState toggleFlags)
         {
             if (toggleFlags == 0) return;

--- a/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
+++ b/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
@@ -10,8 +10,8 @@ namespace POESKillTree.SkillTreeFiles
         [Flags]
         public enum HighlightState
         {
-            FromSearch = 1, FromAttrib = 2, FromNode = 4,
-            All = FromSearch | FromAttrib | FromNode
+            FromSearch = 1, FromAttrib = 2, FromNode = 4, Crossed = 8,
+            All = FromSearch | FromAttrib | FromNode | Crossed
         }
 
         public Dictionary<SkillNode, HighlightState> nodeHighlights = new Dictionary<SkillNode, HighlightState>();

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -235,18 +235,32 @@ namespace POESKillTree.SkillTreeFiles
         public void DrawHighlights(NodeHighlighter nh)
         {
             var hpen = new Pen(Brushes.White, 20);
+            var crossPen = new Pen(Brushes.Red, 20);
             using (DrawingContext dc = picHighlights.RenderOpen())
             {
                 foreach (var pair in nh.nodeHighlights)
                 {
                     // TODO: Make more elegant? Needs profiling.
                     HighlightState hs = pair.Value;
-                    byte red = (byte)(hs.HasFlag(HighlightState.FromSearch) ? 255 : 0);
-                    byte green = (byte)(hs.HasFlag(HighlightState.FromAttrib) ? 255 : 0);
-                    byte blue = (byte)(hs.HasFlag(HighlightState.FromNode) ? 255 : 0);
-                    hpen = new Pen(new SolidColorBrush(Color.FromRgb(red, green, blue)), 20);
 
-                    dc.DrawEllipse(null, hpen, pair.Key.Position, 80, 80);
+                    if (hs != HighlightState.Crossed)
+                    {
+                        byte red = (byte)(hs.HasFlag(HighlightState.FromSearch) ? 255 : 0);
+                        byte green = (byte)(hs.HasFlag(HighlightState.FromAttrib) ? 255 : 0);
+                        byte blue = (byte)(hs.HasFlag(HighlightState.FromNode) ? 255 : 0);
+                        hpen = new Pen(new SolidColorBrush(Color.FromRgb(red, green, blue)), 20);
+
+                        dc.DrawEllipse(null, hpen, pair.Key.Position, 80, 80);
+                    }
+
+                    if (hs.HasFlag(HighlightState.Crossed))
+                    {
+                        // Crossed nodes get highlighted with two crossing lines.
+                        var x = pair.Key.Position.X;
+                        var y = pair.Key.Position.Y;
+                        dc.DrawLine(crossPen, new Point(x + 50, y + 70), new Point(x - 50, y - 70));
+                        dc.DrawLine(crossPen, new Point(x + 50, y - 70), new Point(x - 50, y + 70));
+                    }
                 }
             }
         }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -758,17 +758,51 @@ namespace POESKillTree.SkillTreeFiles
             return result;
         }
 
-        public void ToggleNodeHighlight(SkillNode node)
+        /// <summary>
+        /// Changes the HighlightState of the node:
+        /// None -> FromNode -> Crossed -> None -> ...
+        /// (preserves other HighlightStates than FromNode and Crossed)
+        /// </summary>
+        /// <param name="node">Node to change the HighlightState for</param>
+        public void CycleNodeHighlightForward(SkillNode node)
         {
-            _nodeHighlighter.ToggleHighlightNode(node, HighlightState.FromNode);
-            _nodeHighlighter.UnhighlightNode(node, HighlightState.Crossed);
+            if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.FromNode))
+            {
+                _nodeHighlighter.UnhighlightNode(node, HighlightState.FromNode);
+                _nodeHighlighter.HighlightNode(node, HighlightState.Crossed);
+            } 
+            else if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Crossed))
+            {
+                _nodeHighlighter.UnhighlightNode(node, HighlightState.Crossed);
+            }
+            else
+            {
+                _nodeHighlighter.HighlightNode(node, HighlightState.FromNode);
+            }
             DrawHighlights(_nodeHighlighter);
         }
 
-        public void ToggleNodeCross(SkillNode node)
+        /// <summary>
+        /// Changes the HighlightState of the node:
+        /// ... <- None <- FromNode <- Crossed <- None
+        /// (preserves other HighlightStates than FromNode and Crossed)
+        /// </summary>
+        /// <param name="node">Node to change the HighlightState for</param>
+        public void CycleNodeHighlightBackward(SkillNode node)
         {
-            _nodeHighlighter.ToggleHighlightNode(node, HighlightState.Crossed);
-            _nodeHighlighter.UnhighlightNode(node, HighlightState.FromNode);
+            if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Crossed))
+            {
+                _nodeHighlighter.UnhighlightNode(node, HighlightState.Crossed);
+                _nodeHighlighter.HighlightNode(node, HighlightState.FromNode);
+            }
+            else if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.FromNode))
+            {
+                _nodeHighlighter.UnhighlightNode(node, HighlightState.FromNode);
+            }
+            else
+            {
+                _nodeHighlighter.HighlightNode(node, HighlightState.Crossed);
+            }
             DrawHighlights(_nodeHighlighter);
         }
 

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -761,12 +761,14 @@ namespace POESKillTree.SkillTreeFiles
         public void ToggleNodeHighlight(SkillNode node)
         {
             _nodeHighlighter.ToggleHighlightNode(node, HighlightState.FromNode);
+            _nodeHighlighter.UnhighlightNode(node, HighlightState.Crossed);
             DrawHighlights(_nodeHighlighter);
         }
 
         public void ToggleNodeCross(SkillNode node)
         {
             _nodeHighlighter.ToggleHighlightNode(node, HighlightState.Crossed);
+            _nodeHighlighter.UnhighlightNode(node, HighlightState.FromNode);
             DrawHighlights(_nodeHighlighter);
         }
 

--- a/WPFSKillTree/Views/HotkeysWindow.xaml
+++ b/WPFSKillTree/Views/HotkeysWindow.xaml
@@ -34,6 +34,7 @@
             <RowDefinition/>
             <RowDefinition/>
             <RowDefinition/>
+            <RowDefinition/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="140"/>
@@ -136,7 +137,13 @@
         <TextBlock Grid.Row="20" Grid.Column="1" Grid.ColumnSpan="3">
             <l:Catalog Message="(Attributes) Highlight corresponding nodes in Skill tree"/>
         </TextBlock>
-        <Button Grid.Row="21" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,10,0,0" x:Name="btnPopupClose" Click="btnPopupClose_Click">
+        <TextBlock Grid.Row="21" Grid.Column="0" Background="{DynamicResource AccentColorBrush4}">
+            <l:Catalog Message="Shift + Right Click"/>
+        </TextBlock>
+        <TextBlock Grid.Row="21" Grid.Column="1" Grid.ColumnSpan="3" Background="{DynamicResource AccentColorBrush4}">
+            <l:Catalog Message="(Attributes) Cross corresponding nodes out in Skill tree"/>
+        </TextBlock>
+        <Button Grid.Row="22" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,10,0,0" x:Name="btnPopupClose" Click="btnPopupClose_Click">
             <l:Catalog Message="Close"/>
         </Button>
     </Grid>

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -855,12 +855,13 @@ namespace POESKillTree.Views
                         // Can't use using because Control is also in System.Windows and that is used elsewhere.
                         if (System.Windows.Forms.Control.ModifierKeys.HasFlag(System.Windows.Forms.Keys.Shift))
                         {
-                            // Cross on shift+right-click
-                            Tree.ToggleNodeCross(node);
+                            // Backward on shift+RMB
+                            Tree.CycleNodeHighlightBackward(node);
                         }
                         else
                         {
-                            Tree.ToggleNodeHighlight(node);
+                            // Forward on RMB
+                            Tree.CycleNodeHighlightForward(node);
                         }
                         e.Handled = true;
                     }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -852,13 +852,16 @@ namespace POESKillTree.Views
                 {
                     if (_lastMouseButton == MouseButton.Right)
                     {
-                        Tree.ToggleNodeHighlight(node);
-                        e.Handled = true;
-                    }
-                    else if (_lastMouseButton == MouseButton.Middle)
-                    {
-                        // Cross on middle-click
-                        Tree.ToggleNodeCross(node);
+                        // Can't use using because Control is also in System.Windows and that is used elsewhere.
+                        if (System.Windows.Forms.Control.ModifierKeys.HasFlag(System.Windows.Forms.Keys.Shift))
+                        {
+                            // Cross on shift+right-click
+                            Tree.ToggleNodeCross(node);
+                        }
+                        else
+                        {
+                            Tree.ToggleNodeHighlight(node);
+                        }
                         e.Handled = true;
                     }
                     else

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -855,6 +855,12 @@ namespace POESKillTree.Views
                         Tree.ToggleNodeHighlight(node);
                         e.Handled = true;
                     }
+                    else if (_lastMouseButton == MouseButton.Middle)
+                    {
+                        // Cross on middle-click
+                        Tree.ToggleNodeCross(node);
+                        e.Handled = true;
+                    }
                     else
                     {
                         // Toggle whether the node is included in the tree

--- a/WPFSKillTree/Views/OptimizerControllerWindow.xaml.cs
+++ b/WPFSKillTree/Views/OptimizerControllerWindow.xaml.cs
@@ -80,8 +80,7 @@ namespace POESKillTree.Views
             if (e.Error is InvalidOperationException)
             {
                 // Show a dialog and close this if the omitted nodes disconnect the tree.
-                // TODO: wording might need to be improved
-                Popup.Warning(L10n.Message("You cannot omit nodes disconnecting the tree!"));
+                Popup.Warning(L10n.Message("You cannot cross out nodes so the tree gets disconnected!"));
                 Close();
                 return;
             }


### PR DESCRIPTION
Added another HighlightState for nodes that is accessible with shift+right-click.
Crossed nodes get ignored by the optimizer and SkillTree.GetShortestPathTo.
If omitting nodes disconnect the tree for the optimizer, a popup is shown (Visual Studio stops after the exception that gets handled later, so to see the popup, press F5).
See Issue #145 