### PR TITLE
Separated node tagging from highlighting

### DIFF
--- a/UnitTests/TestGeneticAlgorithmEasy.cs
+++ b/UnitTests/TestGeneticAlgorithmEasy.cs
@@ -32,11 +32,11 @@ namespace UnitTests
             SkillNode coldhearted = SkillTree.Skillnodes.Values.Where(n => n.Name == "Coldhearted Calculation").First();
             SkillNode voidBarrier = SkillTree.Skillnodes.Values.Where(n => n.Name == "Void Barrier").First();
 
-            Tree._nodeHighlighter.ToggleHighlightNode(coldhearted, NodeHighlighter.HighlightState.FromNode);
-            Tree._nodeHighlighter.ToggleHighlightNode(voidBarrier, NodeHighlighter.HighlightState.FromNode);
+            Tree._nodeHighlighter.ToggleHighlightNode(coldhearted, NodeHighlighter.HighlightState.Checked);
+            Tree._nodeHighlighter.ToggleHighlightNode(voidBarrier, NodeHighlighter.HighlightState.Checked);
             Tree.Chartype = 6; // Shadow
 
-            Tree.SkillAllHighlightedNodes();
+            Tree.SkillAllTaggedNodes();
             /// Obviously possible to break when tree changes, like most other tests.
             /// The correct value would be whatever is shown in the app + 1.
             Assert.IsTrue(Tree.SkilledNodes.Count == 14);

--- a/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
+++ b/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
@@ -10,8 +10,10 @@ namespace POESKillTree.SkillTreeFiles
         [Flags]
         public enum HighlightState
         {
-            FromSearch = 1, FromAttrib = 2, FromNode = 4, Crossed = 8,
-            All = FromSearch | FromAttrib | FromNode | Crossed
+            FromSearch = 1, FromAttrib = 2, Checked = 4, Crossed = 8,
+            Highlights = FromSearch | FromAttrib,
+            Tags = Checked | Crossed,
+            All = FromSearch | FromAttrib | Checked | Crossed
         }
 
         public Dictionary<SkillNode, HighlightState> nodeHighlights = new Dictionary<SkillNode, HighlightState>();
@@ -74,6 +76,20 @@ namespace POESKillTree.SkillTreeFiles
         {
             UnhighlightAllNodes(replaceFlags);
             HighlightNodes(newNodes, replaceFlags);
+        }
+
+        /// <summary>
+        /// For all nodes that have at least one of the ifFlags:
+        /// Removes flags not in ifFlags, adds newFlags.
+        /// </summary>
+        public void HighlightNodesIf(HighlightState newFlags, HighlightState ifFlags)
+        {
+            var pairs = nodeHighlights.Where(pair => (pair.Value & ifFlags) > 0).ToArray();
+            foreach (var pair in pairs)
+            {
+                nodeHighlights[pair.Key] &= ifFlags;
+                nodeHighlights[pair.Key] |= newFlags;
+            }
         }
     }
 }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -243,6 +243,7 @@ namespace POESKillTree.SkillTreeFiles
         {
             var hpen = new Pen(Brushes.White, 20);
             var crossPen = new Pen(Brushes.Red, 20);
+            var checkPen = new Pen(Brushes.Lime, 20);
             using (DrawingContext dc = picHighlights.RenderOpen())
             {
                 foreach (var pair in nh.nodeHighlights)
@@ -250,21 +251,30 @@ namespace POESKillTree.SkillTreeFiles
                     // TODO: Make more elegant? Needs profiling.
                     HighlightState hs = pair.Value;
 
-                    if (hs != HighlightState.Crossed)
+                    // These should not appear together, so not checking for their conjunction.
+                    if (hs != HighlightState.Crossed && hs != HighlightState.Checked)
                     {
                         byte red = (byte)(hs.HasFlag(HighlightState.FromSearch) ? 255 : 0);
                         byte green = (byte)(hs.HasFlag(HighlightState.FromAttrib) ? 255 : 0);
-                        byte blue = (byte)(hs.HasFlag(HighlightState.FromNode) ? 255 : 0);
-                        hpen = new Pen(new SolidColorBrush(Color.FromRgb(red, green, blue)), 20);
+                        hpen = new Pen(new SolidColorBrush(Color.FromRgb(red, green, 0)), 20);
 
                         dc.DrawEllipse(null, hpen, pair.Key.Position, 80, 80);
                     }
 
+                    var x = pair.Key.Position.X;
+                    var y = pair.Key.Position.Y;
+
+                    if (hs.HasFlag(HighlightState.Checked))
+                    {
+                        // Checked nodes get highlighted with two green lines resembling a check mark.
+                        // TODO a better looking check mark
+                        dc.DrawLine(checkPen, new Point(x - 10, y + 50), new Point(x - 50, y + 20));
+                        dc.DrawLine(checkPen, new Point(x + 50, y - 50), new Point(x - 22, y + 52));
+                    }
+
                     if (hs.HasFlag(HighlightState.Crossed))
                     {
-                        // Crossed nodes get highlighted with two crossing lines.
-                        var x = pair.Key.Position.X;
-                        var y = pair.Key.Position.Y;
+                        // Crossed nodes get highlighted with two crossing red lines.
                         dc.DrawLine(crossPen, new Point(x + 50, y + 70), new Point(x - 50, y - 70));
                         dc.DrawLine(crossPen, new Point(x + 50, y - 70), new Point(x - 50, y + 70));
                     }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -769,9 +769,9 @@ namespace POESKillTree.SkillTreeFiles
         /// <param name="node">Node to change the HighlightState for</param>
         public void CycleNodeHighlightForward(SkillNode node)
         {
-            if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.FromNode))
+            if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Checked))
             {
-                _nodeHighlighter.UnhighlightNode(node, HighlightState.FromNode);
+                _nodeHighlighter.UnhighlightNode(node, HighlightState.Checked);
                 _nodeHighlighter.HighlightNode(node, HighlightState.Crossed);
             } 
             else if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Crossed))
@@ -780,7 +780,7 @@ namespace POESKillTree.SkillTreeFiles
             }
             else
             {
-                _nodeHighlighter.HighlightNode(node, HighlightState.FromNode);
+                _nodeHighlighter.HighlightNode(node, HighlightState.Checked);
             }
             DrawHighlights(_nodeHighlighter);
         }
@@ -796,11 +796,11 @@ namespace POESKillTree.SkillTreeFiles
             if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Crossed))
             {
                 _nodeHighlighter.UnhighlightNode(node, HighlightState.Crossed);
-                _nodeHighlighter.HighlightNode(node, HighlightState.FromNode);
+                _nodeHighlighter.HighlightNode(node, HighlightState.Checked);
             }
-            else if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.FromNode))
+            else if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Checked))
             {
-                _nodeHighlighter.UnhighlightNode(node, HighlightState.FromNode);
+                _nodeHighlighter.UnhighlightNode(node, HighlightState.Checked);
             }
             else
             {
@@ -851,7 +851,25 @@ namespace POESKillTree.SkillTreeFiles
 
         public void UnhighlightAllNodes()
         {
-            _nodeHighlighter.UnhighlightAllNodes(HighlightState.All);
+            _nodeHighlighter.UnhighlightAllNodes(HighlightState.Highlights);
+        }
+
+        public void UntagAllNodes()
+        {
+            _nodeHighlighter.UnhighlightAllNodes(HighlightState.Tags);
+            DrawHighlights(_nodeHighlighter);
+        }
+
+        public void CheckAllHighlightedNodes()
+        {
+            _nodeHighlighter.HighlightNodesIf(HighlightState.Checked, HighlightState.Highlights);
+            DrawHighlights(_nodeHighlighter);
+        }
+
+        public void CrossAllHighlightedNodes()
+        {
+            _nodeHighlighter.HighlightNodesIf(HighlightState.Crossed, HighlightState.Highlights);
+            DrawHighlights(_nodeHighlighter);
         }
 
         public static Dictionary<string, List<float>> ImplicitAttributes(Dictionary<string, List<float>> attribs, int level)
@@ -968,7 +986,7 @@ namespace POESKillTree.SkillTreeFiles
             return TreeAddress + Convert.ToBase64String(b).Replace("/", "_").Replace("+", "-");
         }
 
-        public void SkillAllHighlightedNodes()
+        public void SkillAllTaggedNodes()
         {
             if (_nodeHighlighter == null)
                 return;
@@ -983,7 +1001,7 @@ namespace POESKillTree.SkillTreeFiles
                     {
                         toOmit.Add(entry.Key.Id);
                     }
-                    else
+                    else if (entry.Value.HasFlag(HighlightState.Checked))
                     {
                         nodes.Add(entry.Key.Id);
                     }
@@ -996,7 +1014,7 @@ namespace POESKillTree.SkillTreeFiles
         {
             if (targetNodeIds.Count == 0)
             {
-                Popup.Info(L10n.Message("Please highlight non-skilled nodes by right-clicking them."));
+                Popup.Info(L10n.Message("Please tag non-skilled nodes by right-clicking them."));
                 return;
             }
 

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -763,11 +763,11 @@ namespace POESKillTree.SkillTreeFiles
 
         /// <summary>
         /// Changes the HighlightState of the node:
-        /// None -> FromNode -> Crossed -> None -> ...
-        /// (preserves other HighlightStates than FromNode and Crossed)
+        /// None -> Checked -> Crossed -> None -> ...
+        /// (preserves other HighlightStates than Checked and Crossed)
         /// </summary>
         /// <param name="node">Node to change the HighlightState for</param>
-        public void CycleNodeHighlightForward(SkillNode node)
+        public void CycleNodeTagForward(SkillNode node)
         {
             if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Checked))
             {
@@ -787,11 +787,11 @@ namespace POESKillTree.SkillTreeFiles
 
         /// <summary>
         /// Changes the HighlightState of the node:
-        /// ... <- None <- FromNode <- Crossed <- None
-        /// (preserves other HighlightStates than FromNode and Crossed)
+        /// ... <- None <- Checked <- Crossed <- None
+        /// (preserves other HighlightStates than Checked and Crossed)
         /// </summary>
         /// <param name="node">Node to change the HighlightState for</param>
-        public void CycleNodeHighlightBackward(SkillNode node)
+        public void CycleNodeTagBackward(SkillNode node)
         {
             if (_nodeHighlighter.NodeHasHighlights(node, HighlightState.Crossed))
             {

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -454,12 +454,20 @@
                         <ContentControl Template="{StaticResource DownloadIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem Click="Menu_SkillHighlightedNodes">
+                <MenuItem Click="Menu_SkillTaggedNodes">
                     <MenuItem.Header>
-                        <l:Catalog Message="Skill _Highlighted Nodes" />
+                        <l:Catalog Message="Skill _Tagged Nodes" />
                     </MenuItem.Header>
                     <MenuItem.Icon>
                         <ContentControl Template="{StaticResource SkillIcon}" />
+                    </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Click="Menu_UntagAllNodes">
+                    <MenuItem.Header>
+                        <l:Catalog Message="Un_tag All Nodes" />
+                    </MenuItem.Header>
+                    <MenuItem.Icon>
+                        <ContentControl Template="{StaticResource CircelIcon}" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Click="Menu_UnhighlightAllNodes">
@@ -469,6 +477,16 @@
                     <MenuItem.Icon>
                         <ContentControl Template="{StaticResource CircelIcon}" />
                     </MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Click="Menu_CheckAllHighlightedNodes">
+                    <MenuItem.Header>
+                        <l:Catalog Message="_Check-tag highlighted Nodes" />
+                    </MenuItem.Header>
+                </MenuItem>
+                <MenuItem Click="Menu_CrossAllHighlightedNodes">
+                    <MenuItem.Header>
+                        <l:Catalog Message="C_ross-tag highlighted Nodes" />
+                    </MenuItem.Header>
                 </MenuItem>
                 <MenuItem Click="Menu_CopyStats">
                     <MenuItem.Header>

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -893,12 +893,12 @@ namespace POESKillTree.Views
                         if (System.Windows.Forms.Control.ModifierKeys.HasFlag(System.Windows.Forms.Keys.Shift))
                         {
                             // Backward on shift+RMB
-                            Tree.CycleNodeHighlightBackward(node);
+                            Tree.CycleNodeTagBackward(node);
                         }
                         else
                         {
                             // Forward on RMB
-                            Tree.CycleNodeHighlightForward(node);
+                            Tree.CycleNodeTagForward(node);
                         }
                         e.Handled = true;
                     }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -286,13 +286,13 @@ namespace POESKillTree.Views
 
         #region Menu
 
-        private void Menu_SkillHighlightedNodes(object sender, RoutedEventArgs e)
+        private void Menu_SkillTaggedNodes(object sender, RoutedEventArgs e)
         {
             var currentCursor = Cursor;
             try
             {
                 Cursor = Cursors.Wait;
-                Tree.SkillAllHighlightedNodes();
+                Tree.SkillAllTaggedNodes();
                 UpdateUI();
                 tbSkillURL.Text = Tree.SaveToURL();
             }
@@ -302,10 +302,25 @@ namespace POESKillTree.Views
             }
         }
 
+        private void Menu_UntagAllNodes(object sender, RoutedEventArgs e)
+        {
+            Tree.UntagAllNodes();
+        }
+
         private void Menu_UnhighlightAllNodes(object sender, RoutedEventArgs e)
         {
             Tree.UnhighlightAllNodes();
             ClearSearch();
+        }
+
+        private void Menu_CheckAllHighlightedNodes(object sender, RoutedEventArgs e)
+        {
+            Tree.CheckAllHighlightedNodes();
+        }
+
+        private void Menu_CrossAllHighlightedNodes(object sender, RoutedEventArgs e)
+        {
+            Tree.CrossAllHighlightedNodes();
         }
 
         private void Menu_ScreenShot(object sender, RoutedEventArgs e)

--- a/WPFSKillTree/Views/OptimizerControllerWindow.xaml.cs
+++ b/WPFSKillTree/Views/OptimizerControllerWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace POESKillTree.Views
             if (e.Error is InvalidOperationException)
             {
                 // Show a dialog and close this if the omitted nodes disconnect the tree.
-                Popup.Warning(L10n.Message("The optimizer was unable to find a conforming tree.\nPlease change skill node highlighting and try again."));
+                Popup.Warning(L10n.Message("The optimizer was unable to find a conforming tree.\nPlease change skill node tagging and try again."));
                 Close();
                 return;
             }


### PR DESCRIPTION
Fixes #149.

I don't know if "Check-tag highlighted Nodes" and "Cross-tag highlighted Nodes" are particularly useful.
If you don't think they clutter the menu, someone would need to add icons for the menu entries if we want to have icons for every menu entry (that might not be the case).