### PR TITLE
Updated Frenzy charge attributes

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -53,8 +53,9 @@ namespace POESKillTree.SkillTreeFiles
             {"+# Maximum Power Charge", 3},
             {"#% Additional Elemental Resistance per Endurance Charge", 4},
             {"#% Physical Damage Reduction per Endurance Charge", 4},
-            {"#% Attack Speed Increase per Frenzy Charge", 5},
-            {"#% Cast Speed Increase per Frenzy Charge", 5},
+            {"#% Attack Speed Increase per Frenzy Charge", 4},
+            {"#% Cast Speed Increase per Frenzy Charge", 4},
+            {"#% More Damage per Frenzy Charge", 4},
             {"#% Critical Strike Chance Increase per Power Charge", 50},
         };
 


### PR DESCRIPTION
Hi, 

I noticed that the 4% more damage frenzy charge attribute was missing and that the cast and attack speed attributes were the old values.

I went ahead and changed them (hope you don't mind, I'm new to this pull-request thing)