### PR TITLE
Fix for problem with Skill tagged nodes and small search spaces

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/SteinerTrees/GeneticAlgorithm.cs
+++ b/WPFSKillTree/SkillTreeFiles/SteinerTrees/GeneticAlgorithm.cs
@@ -278,13 +278,13 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
 
 #if DEBUG
             stopwatch.Stop();
-            //Console.Write("Evaluation time for " + generationCount + " : ");
-            //Console.WriteLine(stopwatch.ElapsedMilliseconds + " ms");
-            //Console.WriteLine("Average health: " + averageHealth / populationSize);
-            //Console.WriteLine("Average bits set: " + averageBitsSet / populationSize);
-            //Console.WriteLine("Average age: " + averageAge / populationSize);
-            //Console.WriteLine("Accepted new states (all/worse): " + acceptedTotal + "/" + acceptedWorse);
-            //Console.WriteLine("Sampler entries: " + sampler.EntryCount);
+            //Debug.Write("Evaluation time for " + generationCount + " : ");
+            //Debug.WriteLine(stopwatch.ElapsedMilliseconds + " ms");
+            //Debug.WriteLine("Average health: " + averageHealth / populationSize);
+            //Debug.WriteLine("Average bits set: " + averageBitsSet / populationSize);
+            //Debug.WriteLine("Average age: " + averageAge / populationSize);
+            //Debug.WriteLine("Accepted new states (all/worse): " + acceptedTotal + "/" + acceptedWorse);
+            //Debug.WriteLine("Sampler entries: " + sampler.EntryCount);
             
             stopwatch.Restart();
 #endif
@@ -293,7 +293,7 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
             {
                 // This is actually a pretty serious problem.
                 population = createPopulation();
-                Console.WriteLine("Entire population was infertile (Generation " +
+                Debug.WriteLine("Entire population was infertile (Generation " +
                                    generationCount + ").");
                 //Debug.Fail("Population went extinct, not good...");
                 return generationCount;
@@ -318,9 +318,9 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
 
 #if DEBUG
             stopwatch.Stop();
-            //Console.WriteLine("Best value so far: " + (1500 - bestSolution.Fitness));
-            //Console.WriteLine("------------------");
-            //Console.Out.Flush();
+            //Debug.WriteLine("Best value so far: " + (1500 - bestSolution.Fitness));
+            //Debug.WriteLine("------------------");
+            //Debug.Out.Flush();
 #endif
 
             return generationCount;

--- a/WPFSKillTree/SkillTreeFiles/SteinerTrees/Steiner.cs
+++ b/WPFSKillTree/SkillTreeFiles/SteinerTrees/Steiner.cs
@@ -155,9 +155,11 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
         ///  Returns the maxGeneration for initializeGA depending on the searchSpace size.
         ///  Returns 0.3 * 20000/searchSpace if searchSpace is < 150 and 0.3 * searchSpace
         ///  otherwise. This means duration * population is constant for searchSpace < 150.
+        ///  If searchSpace is < 10 it is treated as being 10. This stops the value from
+        ///  becoming to high for very low searchSpaces.
         /// </summary>
         private Func<int, double> durationFct = (searchSpace) =>
-            (0.3 * (searchSpace < 150 ? 20000.0 / searchSpace : searchSpace));
+            (0.3 * (searchSpace < 150 ? 20000.0 / Math.Max(searchSpace, 10) : searchSpace));
         /// <summary>
         ///  Returns the populationSize for initializeGA depending on
         ///  the searchSpace size. Returns 1.5 * searchSpace at the moment.
@@ -332,6 +334,9 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
 
             MinimalSpanningTree leastSolution = new MinimalSpanningTree(targetNodes, distances);
             leastSolution.Span(startFrom: startNodes);
+            // Saving the leastSolution as initial solution. Makes sure there is always a
+            // solution even if the search space is empty.
+            BestSolution = SpannedMstToSkillnodes(leastSolution, false);
 
             int maxEdgeDistance = 0;
             foreach (GraphEdge edge in leastSolution.SpanningEdges)
@@ -410,7 +415,7 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
             if (randomSeed == null) randomSeed = DateTime.Now.GetHashCode();
             ga = new GeneticAlgorithm(fitnessFunction, new Random(randomSeed.Value));
 
-            Console.WriteLine("Search space dimension: " + searchSpaceBase.Count);
+            Debug.WriteLine("Search space dimension: " + searchSpaceBase.Count);
 
             int populationSize = (int)(populationModifier * populationFct(searchSpaceBase.Count));
             maxGeneration = (int)(durationModifier * durationFct(searchSpaceBase.Count));

--- a/WPFSKillTree/SkillTreeFiles/SteinerTrees/Steiner.cs
+++ b/WPFSKillTree/SkillTreeFiles/SteinerTrees/Steiner.cs
@@ -155,11 +155,9 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
         ///  Returns the maxGeneration for initializeGA depending on the searchSpace size.
         ///  Returns 0.3 * 20000/searchSpace if searchSpace is < 150 and 0.3 * searchSpace
         ///  otherwise. This means duration * population is constant for searchSpace < 150.
-        ///  If searchSpace is < 10 (and not 0) it is treated as being 10. This stops the value from
-        ///  becoming to high for very low searchSpaces.
         /// </summary>
         private Func<int, double> durationFct = (searchSpace) =>
-            (0.3 * (searchSpace < 150 && searchSpace > 0 ? 20000.0 / Math.Max(searchSpace, 10) : searchSpace));
+            (0.3 * (searchSpace < 150 ? 20000.0 / searchSpace : searchSpace));
         /// <summary>
         ///  Returns the populationSize for initializeGA depending on
         ///  the searchSpace size. Returns 1.5 * searchSpace at the moment.

--- a/WPFSKillTree/SkillTreeFiles/SteinerTrees/Steiner.cs
+++ b/WPFSKillTree/SkillTreeFiles/SteinerTrees/Steiner.cs
@@ -155,11 +155,11 @@ namespace POESKillTree.SkillTreeFiles.SteinerTrees
         ///  Returns the maxGeneration for initializeGA depending on the searchSpace size.
         ///  Returns 0.3 * 20000/searchSpace if searchSpace is < 150 and 0.3 * searchSpace
         ///  otherwise. This means duration * population is constant for searchSpace < 150.
-        ///  If searchSpace is < 10 it is treated as being 10. This stops the value from
+        ///  If searchSpace is < 10 (and not 0) it is treated as being 10. This stops the value from
         ///  becoming to high for very low searchSpaces.
         /// </summary>
         private Func<int, double> durationFct = (searchSpace) =>
-            (0.3 * (searchSpace < 150 ? 20000.0 / Math.Max(searchSpace, 10) : searchSpace));
+            (0.3 * (searchSpace < 150 && searchSpace > 0 ? 20000.0 / Math.Max(searchSpace, 10) : searchSpace));
         /// <summary>
         ///  Returns the populationSize for initializeGA depending on
         ///  the searchSpace size. Returns 1.5 * searchSpace at the moment.

--- a/WPFSKillTree/Views/OptimizerControllerWindow.xaml.cs
+++ b/WPFSKillTree/Views/OptimizerControllerWindow.xaml.cs
@@ -80,7 +80,7 @@ namespace POESKillTree.Views
             steinerSolver.InitializeSolver(targetNodes, nodesToOmit);
 #if DEBUG
             stopwatch.Stop();
-            Console.WriteLine("Initialization took " + stopwatch.ElapsedMilliseconds + " ms\n-----------------");
+            Debug.WriteLine("Initialization took " + stopwatch.ElapsedMilliseconds + " ms\n-----------------");
 #endif
         }
 
@@ -125,7 +125,7 @@ namespace POESKillTree.Views
             }
 #if DEBUG
             stopwatch.Stop();
-            Console.WriteLine("Finished in " + stopwatch.ElapsedMilliseconds + " ms\n==================");
+            Debug.WriteLine("Finished in " + stopwatch.ElapsedMilliseconds + " ms\n==================");
 #endif
             e.Result = steinerSolver.BestSolution;
         }


### PR DESCRIPTION
Fixed the problem described here https://www.reddit.com/r/pathofexile/comments/3cyk54/poeskilltree_220_the_awakening_update/ct0iiaf
Small search spaces took to long and directly adjacent tagged nodes let to a crash.
(also changed Console.WriteLine to Debug.WriteLine because I stumbled upon that)