### PR TITLE
Added support for Arrow Dancing keynode (old Ondar's Guile)

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -329,7 +329,7 @@ namespace POESKillTree.SkillTreeFiles
                     {
                         Id = nd.id,
                         Name = nd.dn,
-                        attributes = nd.dn.Contains("Jewel Socket") ? new string[1] {"+1 Jewel Socket"} : nd.sd,
+                        attributes = nd.dn.Contains("Jewel Socket") ? new string[1] { "+1 Jewel Socket" } : SplitMultilineAttributes(nd.sd),
                         Orbit = nd.o,
                         OrbitIndex = nd.oidx,
                         Icon = nd.icon,
@@ -1037,6 +1037,23 @@ namespace POESKillTree.SkillTreeFiles
             this.DrawHighlights(_nodeHighlighter);
 
             UpdateAvailNodes();
+        }
+
+        /// <summary>
+        /// Splits multiline attribute strings (i.e. strings containing "\n" characters) into multiple attribute strings.
+        /// </summary>
+        /// <param name="attrs">An array of attribute strings to split.</param>
+        /// <returns>An array of attributes strings.</returns>
+        private static string[] SplitMultilineAttributes(string[] attrs)
+        {
+            if (attrs == null || attrs.Length == 0)
+                return attrs;
+
+            List<string> split = new List<string>();
+            for (int i = 0; i < attrs.Length; ++i)
+                split.AddRange(attrs[i].Split('\n'));
+
+            return split.ToArray();
         }
 
         public void UpdateAvailNodes(bool draw = true)


### PR DESCRIPTION
Fixed Unwavering Stance keynode not being applied.
Added support for Arrow Dancing keynode (old Ondar's Guile).
Added multiline attribute splitting for skill nodes (e.g. Unwavering Stance, Arrow Dancing, etc.).

Just found out that even Unwavering Stance in 1.3 patch didn't have 2 attributes, but only 1 with "Cannot Evade enemy Attacks\nCannot be Stunned" string. So i added attribute splitting to skill node construction.