### PR TITLE
Fixed attribute higlighting searching by substring

### DIFF
--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -835,11 +835,10 @@ namespace POESKillTree.Views
         private void TextBlock_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
         {
             var newHighlightedAttribute =
-                Regex.Replace(
-                    Regex.Match(listBox1.SelectedItem.ToString(), @"(?!\d)\w.*\w")
-                        .Value.Replace(@"+", @"\+")
+                "^" + Regex.Replace(listBox1.SelectedItem.ToString()
+                        .Replace(@"+", @"\+")
                         .Replace(@"-", @"\-")
-                        .Replace(@"%", @"\%"), @"\d+", @"\d+");
+                        .Replace(@"%", @"\%"), @"\d+", @"\d+") + "$";
             _highlightedAttribute = newHighlightedAttribute == _highlightedAttribute ? "" : newHighlightedAttribute;
             Tree.HighlightNodesBySearch(_highlightedAttribute, true, false);
         }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -838,7 +838,7 @@ namespace POESKillTree.Views
                 "^" + Regex.Replace(listBox1.SelectedItem.ToString()
                         .Replace(@"+", @"\+")
                         .Replace(@"-", @"\-")
-                        .Replace(@"%", @"\%"), @"\d+", @"\d+") + "$";
+                        .Replace(@"%", @"\%"), @"[0-9]*\.?[0-9]+", @"[0-9]*\.?[0-9]+") + "$";
             _highlightedAttribute = newHighlightedAttribute == _highlightedAttribute ? "" : newHighlightedAttribute;
             Tree.HighlightNodesBySearch(_highlightedAttribute, true, false);
         }


### PR DESCRIPTION
Fixes #173.
Only nodes with the exact same attribute get highlighted.
Might in some cases be actually not want one would want, but at least it
is consistent.