### PR TITLE
Tentative fix for #182

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -202,7 +202,7 @@ namespace POESKillTree.SkillTreeFiles
                 for (int i = 0; i < CharName.Count; i++)
                 {
                     string s = CharName[i];
-                    Vector2D pos = Skillnodes.First(nd => nd.Value.Name.ToUpper() == s.ToUpper()).Value.Position;
+                    Vector2D pos = Skillnodes.First(nd => nd.Value.Name.ToUpperInvariant() == s).Value.Position;
                     dc.DrawRectangle(StartBackgrounds[false].Value, null,
                         new Rect(
                             pos - new Vector2D(StartBackgrounds[false].Key.Width, StartBackgrounds[false].Key.Height),

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -346,9 +346,9 @@ namespace POESKillTree.SkillTreeFiles
                     });
                     if (_rootNodeList.Contains(nd.id))
                     {
-                        if (!_rootNodeClassDictionary.ContainsKey(nd.dn.ToString().ToUpper()))
+                        if (!_rootNodeClassDictionary.ContainsKey(nd.dn.ToString().ToUpperInvariant()))
                         {
-                            _rootNodeClassDictionary.Add(nd.dn.ToString().ToUpper(), nd.id);
+                            _rootNodeClassDictionary.Add(nd.dn.ToString().ToUpperInvariant(), nd.id);
                         }
                         foreach (int linkedNode in nd.ot)
                         {
@@ -483,7 +483,7 @@ namespace POESKillTree.SkillTreeFiles
                 _chartype = value;
                 SkilledNodes.Clear();
                 KeyValuePair<ushort, SkillNode> node =
-                    Skillnodes.First(nd => nd.Value.Name.ToUpper() == CharName[_chartype]);
+                    Skillnodes.First(nd => nd.Value.Name.ToUpperInvariant() == CharName[_chartype]);
                 SkilledNodes.Add(node.Value.Id);
                 UpdateAvailNodes();
                 DrawFaces();
@@ -937,7 +937,7 @@ namespace POESKillTree.SkillTreeFiles
             chartype = b;
 
 
-            SkillNode startnode = Skillnodes.First(nd => nd.Value.Name.ToUpper() == CharName[b].ToUpper()).Value;
+            SkillNode startnode = Skillnodes.First(nd => nd.Value.Name.ToUpperInvariant() == CharName[b]).Value;
             skillednodes.Add(startnode.Id);
             foreach (ushort node in nodes)
             {
@@ -961,7 +961,7 @@ namespace POESKillTree.SkillTreeFiles
         public void Reset()
         {
             SkilledNodes.Clear();
-            KeyValuePair<ushort, SkillNode> node = Skillnodes.First(nd => nd.Value.Name.ToUpper() == CharName[_chartype]);
+            KeyValuePair<ushort, SkillNode> node = Skillnodes.First(nd => nd.Value.Name.ToUpperInvariant() == CharName[_chartype]);
             SkilledNodes.Add(node.Value.Id);
             UpdateAvailNodes();
         }
@@ -979,7 +979,7 @@ namespace POESKillTree.SkillTreeFiles
             int pos = 6;
             foreach (ushort inn in SkilledNodes)
             {
-                if (CharName.Contains(Skillnodes[inn].Name.ToUpper()))
+                if (CharName.Contains(Skillnodes[inn].Name.ToUpperInvariant()))
                     continue;
                 byte[] dbff = BitConverter.GetBytes((Int16)inn);
                 b[pos++] = dbff[1];
@@ -1073,7 +1073,7 @@ namespace POESKillTree.SkillTreeFiles
                 SkillNode node = Skillnodes[inode];
                 foreach (SkillNode skillNode in node.Neighbor)
                 {
-                    if (!CharName.Contains(skillNode.Name) && !SkilledNodes.Contains(skillNode.Id))
+                    if (!CharName.Contains(skillNode.Name.ToUpperInvariant()) && !SkilledNodes.Contains(skillNode.Id))
                         availNodes.Add(skillNode.Id);
                 }
             }
@@ -1125,15 +1125,15 @@ namespace POESKillTree.SkillTreeFiles
             int rootNodeValue;
             var temp = new List<ushort>();
 
-            if (className.ToUpper() == "SHADOW")
+            if (className.ToUpperInvariant() == "SHADOW")
             {
                 className = "SIX";
             }
-            if (className.ToUpper() == "SCION")
+            if (className.ToUpperInvariant() == "SCION")
             {
                 className = "SEVEN";
             }
-            _rootNodeClassDictionary.TryGetValue(className.ToUpper(), out rootNodeValue);
+            _rootNodeClassDictionary.TryGetValue(className.ToUpperInvariant(), out rootNodeValue);
             var classSpecificStartNodes = _startNodeDictionary.Where(kvp => kvp.Value == rootNodeValue).Select(kvp => kvp.Key);
 
             foreach (int node in classSpecificStartNodes)

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -159,11 +159,6 @@ namespace POESKillTree.Views
             recSkillTree.UpdateLayout();
             recSkillTree.Fill = new VisualBrush(Tree.SkillTreeVisual);
 
-            Tree.Chartype =
-                SkillTree.CharName.IndexOf(((string)((ComboBoxItem)cbCharType.SelectedItem).Name).ToUpper());
-            Tree.UpdateAvailNodes();
-            UpdateUI();
-
             _multransform = SkillTree.TRect.Size / new Vector2D(recSkillTree.RenderSize.Width, recSkillTree.RenderSize.Height);
             _addtransform = SkillTree.TRect.TopLeft;
 
@@ -618,10 +613,10 @@ namespace POESKillTree.Views
             {
                 var startnode =
                     SkillTree.Skillnodes.First(
-                        nd => nd.Value.Name.ToUpper() == (SkillTree.CharName[cbCharType.SelectedIndex]).ToUpper()).Value;
+                        nd => nd.Value.Name.ToUpperInvariant() == SkillTree.CharName[cbCharType.SelectedIndex]).Value;
                 Tree.SkilledNodes.Clear();
                 Tree.SkilledNodes.Add(startnode.Id);
-                Tree.Chartype = SkillTree.CharName.IndexOf((SkillTree.CharName[cbCharType.SelectedIndex]).ToUpper());
+                Tree.Chartype = cbCharType.SelectedIndex;
             }
             Tree.UpdateAvailNodes();
             UpdateUI();


### PR DESCRIPTION
Removed the Tree.Chartype assignment causing the exception because it gets overwritten a few lines later anyway (btnLoadBuild_Click()-call).
Changed .ToUpper() to .ToUpperInvariant()-calls, also only the skill node names get uppercased.

If the reason for the problems is the locale dependent `.ToUpper()`, this fixes #182.
We should maybe get someone that had the problem to try this out before merging.