### PR TITLE
Added highlight similar nodes feature

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
+++ b/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
@@ -10,10 +10,10 @@ namespace POESKillTree.SkillTreeFiles
         [Flags]
         public enum HighlightState
         {
-            FromSearch = 1, FromAttrib = 2, Checked = 4, Crossed = 8,
-            Highlights = FromSearch | FromAttrib,
+            FromSearch = 1, FromAttrib = 2, Checked = 4, Crossed = 8, FromHover = 16,
+            Highlights = FromSearch | FromAttrib | FromHover,
             Tags = Checked | Crossed,
-            All = FromSearch | FromAttrib | Checked | Crossed
+            All = FromSearch | FromAttrib | Checked | Crossed | FromHover
         }
 
         public Dictionary<SkillNode, HighlightState> nodeHighlights = new Dictionary<SkillNode, HighlightState>();
@@ -57,7 +57,7 @@ namespace POESKillTree.SkillTreeFiles
             }
         }
 
-        public void HighlightNodes(List<SkillNode> nodes, HighlightState newFlags)
+        public void HighlightNodes(IEnumerable<SkillNode> nodes, HighlightState newFlags)
         {
             foreach (SkillNode node in nodes)
                 HighlightNode(node, newFlags);
@@ -72,7 +72,7 @@ namespace POESKillTree.SkillTreeFiles
                 UnhighlightNode(node, removeFlags);
         }
 
-        public void ReplaceHighlights(List<SkillNode> newNodes, HighlightState replaceFlags)
+        public void ReplaceHighlights(IEnumerable<SkillNode> newNodes, HighlightState replaceFlags)
         {
             UnhighlightAllNodes(replaceFlags);
             HighlightNodes(newNodes, replaceFlags);

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -254,9 +254,17 @@ namespace POESKillTree.SkillTreeFiles
                     // These should not appear together, so not checking for their conjunction.
                     if (hs != HighlightState.Crossed && hs != HighlightState.Checked)
                     {
-                        byte red = (byte)(hs.HasFlag(HighlightState.FromSearch) ? 255 : 0);
-                        byte green = (byte)(hs.HasFlag(HighlightState.FromAttrib) ? 255 : 0);
-                        hpen = new Pen(new SolidColorBrush(Color.FromRgb(red, green, 0)), 20);
+                        // If it has FromHover, don't mix it with the other highlights.
+                        if (hs.HasFlag(HighlightState.FromHover))
+                        {
+                            hpen = new Pen(Brushes.DodgerBlue, 20);
+                        }
+                        else
+                        {
+                            byte red = (byte)(hs.HasFlag(HighlightState.FromSearch) ? 255 : 0);
+                            byte green = (byte)(hs.HasFlag(HighlightState.FromAttrib) ? 255 : 0);
+                            hpen = new Pen(new SolidColorBrush(Color.FromRgb(red, green, 0)), 20);
+                        }
 
                         dc.DrawEllipse(null, hpen, pair.Key.Position, 80, 80);
                     }

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -811,9 +811,12 @@ namespace POESKillTree.SkillTreeFiles
             DrawHighlights(_nodeHighlighter);
         }
 
-        public void HighlightNodesBySearch(string search, bool useregex, bool fromSearchBox)
+        /// <param name="search">The string to search each node name and attribute for.</param>
+        /// <param name="useregex">If the string should be interpreted as a regex.</param>
+        /// <param name="flag">The flag to highlight found nodes with.</param>
+        /// <param name="matchCount">The number of attributes of a node that must match the search to get highlighted, -1 if the count doesn't matter.</param>
+        public void HighlightNodesBySearch(string search, bool useregex, HighlightState flag, int matchCount = -1)
         {
-            HighlightState flag = fromSearchBox ? HighlightState.FromSearch : HighlightState.FromAttrib;
             if (search == "")
             {
                 _nodeHighlighter.UnhighlightAllNodes(flag);
@@ -821,16 +824,18 @@ namespace POESKillTree.SkillTreeFiles
                 return;
             }
 
+            var matchFct = matchCount >= 0 ? (Func<string[], Func<string, bool>, bool>)
+                 ((attributes, predicate) => attributes.Count(predicate) == matchCount)
+                : (attributes, predicate) => attributes.Any(predicate);
             if (useregex)
             {
                 try
                 {
-                    List<SkillNode> nodes =
-                            Skillnodes.Values.Where(
-                                nd =>
-                                    nd.attributes.Any(att => new Regex(search, RegexOptions.IgnoreCase).IsMatch(att)) ||
-                                    new Regex(search, RegexOptions.IgnoreCase).IsMatch(nd.Name) && !nd.IsMastery)
-                                .ToList();
+                    var regex = new Regex(search, RegexOptions.IgnoreCase);
+                    var nodes =
+                        Skillnodes.Values.Where(
+                            nd => matchFct(nd.attributes, att => regex.IsMatch(att)) ||
+                                  regex.IsMatch(nd.Name) && !nd.IsMastery);
                     _nodeHighlighter.ReplaceHighlights(nodes, flag);
                     DrawHighlights(_nodeHighlighter);
                 }
@@ -841,11 +846,11 @@ namespace POESKillTree.SkillTreeFiles
             }
             else
             {
-                List<SkillNode> nodes =
+                search = search.ToLowerInvariant();
+                var nodes =
                     Skillnodes.Values.Where(
-                        nd =>
-                            nd.attributes.Count(att => att.ToLower().Contains(search.ToLower())) != 0 ||
-                            nd.Name.ToLower().Contains(search.ToLower()) && !nd.IsMastery).ToList();
+                        nd => matchFct(nd.attributes, att => att.ToLowerInvariant().Contains(search)) ||
+                              nd.Name.ToLowerInvariant().Contains(search) && !nd.IsMastery);
                 _nodeHighlighter.ReplaceHighlights(nodes, flag);
                 DrawHighlights(_nodeHighlighter);
             }

--- a/WPFSKillTree/Views/HotkeysWindow.xaml
+++ b/WPFSKillTree/Views/HotkeysWindow.xaml
@@ -36,6 +36,7 @@
             <RowDefinition/>
             <RowDefinition/>
             <RowDefinition/>
+            <RowDefinition/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="140"/>
@@ -144,13 +145,19 @@
         <TextBlock Grid.Row="21" Grid.Column="1" Grid.ColumnSpan="3" Background="{DynamicResource AccentColorBrush4}">
             <l:Catalog Message="(Skill node) Toggle skill node highlighting"/>
         </TextBlock>
-        <TextBlock Grid.Row="22" Grid.Column="0" Background="{DynamicResource AccentColorBrush4}">
+        <TextBlock Grid.Row="22" Grid.Column="0">
             <l:Catalog Message="Shift + Right Click"/>
         </TextBlock>
-        <TextBlock Grid.Row="22" Grid.Column="1" Grid.ColumnSpan="3" Background="{DynamicResource AccentColorBrush4}">
+        <TextBlock Grid.Row="22" Grid.Column="1" Grid.ColumnSpan="3">
             <l:Catalog Message="(Skill node) Toggle skill node highlighting (reversed)"/>
         </TextBlock>
-        <Button Grid.Row="23" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,10,0,0" x:Name="btnPopupClose" Click="btnPopupClose_Click">
+        <TextBlock Grid.Row="23" Grid.Column="0" Background="{DynamicResource AccentColorBrush4}">
+            <l:Catalog Message="Shift + Hover"/>
+        </TextBlock>
+        <TextBlock Grid.Row="23" Grid.Column="1" Grid.ColumnSpan="3" Background="{DynamicResource AccentColorBrush4}">
+            <l:Catalog Message="(Skill node) Highlight similar skill nodes"/>
+        </TextBlock>
+        <Button Grid.Row="24" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,10,0,0" x:Name="btnPopupClose" Click="btnPopupClose_Click">
             <l:Catalog Message="Close"/>
         </Button>
     </Grid>

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -12,7 +12,7 @@
         mc:Ignorable="d" x:Class="POESKillTree.Views.MainWindow"
         Title="Path of Exile - Passive Skill Tree Planner" Height="667" Width="1200" SizeChanged="Window_SizeChanged" 
         Closing="Window_Closing" Icon="/POESKillTree;component/logo.ico" Loaded="Window_Loaded" WindowStartupLocation="CenterScreen"
-        PreviewKeyDown="Window_PreviewKeyDown"
+        PreviewKeyDown="Window_PreviewKeyDown" PreviewKeyUp="Window_PreviewKeyUp"
         TextOptions.TextFormattingMode="Display"
         x:Name="window"
         >

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -47,6 +47,11 @@ namespace POESKillTree.Views
     /// </summary>
     public partial class MainWindow : MetroWindow, INotifyPropertyChanged
     {
+        /// <summary>
+        /// The set of keys of which one needs to be pressed to highlight similar nodes on hover.
+        /// </summary>
+        private static readonly Key[] HighlightByHoverKeys = { Key.LeftShift, Key.RightShift };
+
         private readonly PersistentData _persistentData = App.PersistentData;
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -239,7 +244,7 @@ namespace POESKillTree.Views
                 }
             }
 
-            if (e.Key == Key.LeftShift || e.Key == Key.RightShift)
+            if (HighlightByHoverKeys.Any(key => key == e.Key))
             {
                 HighlightNodesByHover();
             }
@@ -257,7 +262,7 @@ namespace POESKillTree.Views
 
         private void Window_PreviewKeyUp(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.LeftShift || e.Key == Key.RightShift)
+            if (HighlightByHoverKeys.Any(key => key == e.Key))
             {
                 HighlightNodesByHover();
             }
@@ -1013,7 +1018,10 @@ namespace POESKillTree.Views
                     }
 
                     _sToolTip.Content = sp;
-                    _sToolTip.IsOpen = true;
+                    if (!HighlightByHoverKeys.Any(Keyboard.IsKeyDown))
+                    {
+                        _sToolTip.IsOpen = true;
+                    }
                     _lasttooltip = tooltip;
                 }
             }
@@ -1044,14 +1052,21 @@ namespace POESKillTree.Views
             }
 
             if (_hoveredNode == null || _hoveredNode.Attributes.Count == 0 ||
-                !Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
+                !HighlightByHoverKeys.Any(Keyboard.IsKeyDown))
             {
+                if (_hoveredNode != null && _hoveredNode.Attributes.Count > 0)
+                {
+                    _sToolTip.IsOpen = true;
+                }
+
                 Tree.HighlightNodesBySearch("", true, NodeHighlighter.HighlightState.FromHover);
 
                 _lastHoveredNode = null;
             }
             else
             {
+                _sToolTip.IsOpen = false;
+
                 if (_lastHoveredNode == _hoveredNode)
                 {
                     // Not necessary, but stops it from continuously searching when holding down shift.


### PR DESCRIPTION
Holding shift while hovering over a node in the skill tree highlights all nodes that contain *all* (can easily be changed to *any*) of the attributes the hovered node has.
*All* feels better imo.
See #183.