### PR TITLE
Fixed issue when persistent data are not being saved completely on Windows shutdown

### DIFF
--- a/WPFSKillTree/Views/App.xaml
+++ b/WPFSKillTree/Views/App.xaml
@@ -4,6 +4,7 @@
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              Startup="App_Startup"
              StartupUri="MainWindow.xaml"
+             Exit="App_Exit"
              DispatcherUnhandledException="App_DispatcherUnhandledException" 
              >
     <Application.Resources>


### PR DESCRIPTION
Fixed persitent data not being saved on shutdown of Windows 7 (x64).
Fixed multi-instance race condition during persistent data saving.

This should fix #195