### PR TITLE
Support for additional class starts from Scion ascendancy class

### DIFF
--- a/WPFSKillTree/Model/Ascendancy/AscendantAdditionalStart.cs
+++ b/WPFSKillTree/Model/Ascendancy/AscendantAdditionalStart.cs
@@ -1,0 +1,16 @@
+namespace POESKillTree.Model.Ascendancy
+{
+    /// <summary>
+    /// Enumeration of possible additional starting points for the Scion through her Ascendancy class.
+    /// </summary>
+    public enum AscendantAdditionalStart
+    {
+        None,
+        Marauder,
+        Ranger,
+        Witch,
+        Duelist,
+        Templar,
+        Shadow
+    }
+}

--- a/WPFSKillTree/SkillTreeFiles/SkillNode.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillNode.cs
@@ -10,6 +10,8 @@ namespace POESKillTree.SkillTreeFiles
         public Dictionary<string, List<float>> Attributes;
         public HashSet<int> Connections = new HashSet<int>();
         public List<SkillNode> Neighbor = new List<SkillNode>();
+        // The subset of neighbors to which connections should be drawn.
+        public readonly List<SkillNode> VisibleNeighbors = new List<SkillNode>();
         public SkillNodeGroup SkillNodeGroup;
         public int A; // "a": 3,
         public string[] attributes; // "sd": ["8% increased Block Recovery"],

--- a/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree-Drawing.cs
@@ -404,7 +404,7 @@ namespace POESKillTree.SkillTreeFiles
                     foreach (ushort n1 in HighlightedNodes)
                     {
 
-                        foreach (SkillNode n2 in Skillnodes[n1].Neighbor)
+                        foreach (SkillNode n2 in Skillnodes[n1].VisibleNeighbors)
                         {
                             if (HighlightedNodes.Contains(n2.Id))
                             {
@@ -515,14 +515,21 @@ namespace POESKillTree.SkillTreeFiles
 
             using (DrawingContext dc = picPathOverlay.RenderOpen())
             {
-                for (int i = -1; i < path.Count - 1; i++)
+                // Draw a connection from a skilled node to the first path node.
+                var skilledNeighbors =
+                    Skillnodes[path[0]].VisibleNeighbors.Where(sn => SkilledNodes.Contains(sn.Id)).ToList();
+                // The node might not be connected to a skilled node through visible neighbors
+                // in which case we don't want to draw a connection anyway.
+                if (skilledNeighbors.Any())
+                    DrawConnection(dc, pen2, skilledNeighbors.First(), Skillnodes[path[0]]);
+                
+                // Draw connections for the path itself (only those that should be visible).
+                for (var i = 0; i < path.Count - 1; i++)
                 {
-                    SkillNode n1 = i == -1
-                        ? Skillnodes[path[i + 1]].Neighbor.First(sn => SkilledNodes.Contains(sn.Id))
-                        : Skillnodes[path[i]];
-                    SkillNode n2 = Skillnodes[path[i + 1]];
-
-                    DrawConnection(dc, pen2, n1, n2);
+                    var n1 = Skillnodes[path[i]];
+                    var n2 = Skillnodes[path[i + 1]];
+                    if (n1.VisibleNeighbors.Contains(n2))
+                        DrawConnection(dc, pen2, n1, n2);
                 }
             }
         }
@@ -536,7 +543,7 @@ namespace POESKillTree.SkillTreeFiles
             {
                 foreach (ushort node in nodes)
                 {
-                    foreach (SkillNode n2 in Skillnodes[node].Neighbor)
+                    foreach (SkillNode n2 in Skillnodes[node].VisibleNeighbors)
                     {
                         if (SkilledNodes.Contains(n2.Id) && (node < n2.Id || !(nodes.Contains(n2.Id))))
                             DrawConnection(dc, pen2, Skillnodes[node], n2);

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -399,6 +399,10 @@ namespace POESKillTree.SkillTreeFiles
                     if (!Skillnodes[ints[1]].Neighbor.Contains(Skillnodes[ints[0]]))
                         Skillnodes[ints[1]].Neighbor.Add(Skillnodes[ints[0]]);
                 }
+                foreach (var skillnode in Skillnodes)
+                {
+                    skillnode.Value.VisibleNeighbors.AddRange(skillnode.Value.Neighbor);
+                }
             }
 
 
@@ -1120,7 +1124,7 @@ namespace POESKillTree.SkillTreeFiles
             {
                 foreach (ushort n1 in SkilledNodes)
                 {
-                    foreach (SkillNode n2 in Skillnodes[n1].Neighbor)
+                    foreach (SkillNode n2 in Skillnodes[n1].VisibleNeighbors)
                     {
                         if (SkilledNodes.Contains(n2.Id))
                         {

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -636,13 +636,22 @@ namespace POESKillTree.SkillTreeFiles
             return skillTree;
         }
 
-        public void ConnectWithStartNodesOf(int chartype)
+        /// <summary>
+        /// Adds (invisible) connections between the Scion's root node and the nodes adjacent to the
+        /// root node of chartype's root node.
+        /// </summary>
+        /// <param name="chartype">Character type whose starting nodes should be connected to the current root node.</param>
+        public void ConnectScionWithStartNodesOf(int chartype)
         {
+            var scion = Skillnodes[(ushort)rootNodeClassDictionary[CharacterNames.Scion]];
             var start = rootNodeClassDictionary[CharName[chartype]];
-            ConnectNodes(GetCharNode(), Skillnodes[(ushort)start].Neighbor);
+            ConnectNodes(scion, Skillnodes[(ushort)start].Neighbor);
         }
 
-        private static void ConnectNodes(SkillNode n1, List<SkillNode> ns)
+        /// <summary>
+        /// Adds (invisible) connections between n1 and all nodes in ns.
+        /// </summary>
+        private static void ConnectNodes(SkillNode n1, IEnumerable<SkillNode> ns)
         {
             foreach (var n2 in ns)
             {
@@ -651,14 +660,20 @@ namespace POESKillTree.SkillTreeFiles
             }
         }
 
+        /// <summary>
+        /// Removes the connections added by <see cref="ConnectScionWithStartNodesOf"/>s.
+        /// </summary>
         public void RemoveStartNodeConnectionToScion(int chartype)
         {
-            var fromNode = Skillnodes[(ushort) rootNodeClassDictionary[CharacterNames.Scion]];
+            var scion = Skillnodes[(ushort) rootNodeClassDictionary[CharacterNames.Scion]];
             var start = rootNodeClassDictionary[CharName[chartype]];
-            UnconnectNodes(fromNode, Skillnodes[(ushort)start].Neighbor);
+            UnconnectNodes(scion, Skillnodes[(ushort)start].Neighbor);
         }
 
-        private static void UnconnectNodes(SkillNode n1, List<SkillNode> ns)
+        /// <summary>
+        /// Removes the connections between n1 and all nodes in ns.
+        /// </summary>
+        private static void UnconnectNodes(SkillNode n1, IEnumerable<SkillNode> ns)
         {
             foreach (var n2 in ns)
             {
@@ -1106,11 +1121,6 @@ namespace POESKillTree.SkillTreeFiles
         public ushort GetCharNodeId()
         {
             return (ushort)rootNodeClassDictionary[CharName[_chartype]];
-        }
-
-        public SkillNode GetCharNode()
-        {
-            return Skillnodes[GetCharNodeId()];
         }
 
         /// <summary>

--- a/WPFSKillTree/ViewModels/PoEBuild.cs
+++ b/WPFSKillTree/ViewModels/PoEBuild.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Xml.Serialization;
 using POESKillTree.Localization;
+using POESKillTree.Model.Ascendancy;
 
 namespace POESKillTree.ViewModels
 {
@@ -17,6 +18,7 @@ namespace POESKillTree.ViewModels
         public string Note { get; set; }
         public string ItemData { get; set; }
         public DateTime LastUpdated { get; set; }
+        public AscendantAdditionalStart AscendantAdditionalStart { get; set; }
 
         [XmlIgnoreAttribute]
         public string Image { get { return "/POESKillTree;component/Images/" + Class + ".jpg"; } }
@@ -66,6 +68,7 @@ namespace POESKillTree.ViewModels
                 Url = build.Url,
                 Note = build.Note,
                 ItemData = build.ItemData,
+                AscendantAdditionalStart = build.AscendantAdditionalStart
             };
         }
     }

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -8,7 +8,9 @@
         xmlns:local="clr-namespace:POESKillTree.Controls"
         xmlns:conv ="clr-namespace:POESKillTree.ViewModels"
         xmlns:items="clr-namespace:POESKillTree.ViewModels.Items"
-    
+        xmlns:converter="clr-namespace:POESKillTree.Utils.Converter"
+        xmlns:views="clr-namespace:POESKillTree.Views"
+
         mc:Ignorable="d" x:Class="POESKillTree.Views.MainWindow"
         Title="Path of Exile - Passive Skill Tree Planner" Height="667" Width="1200" SizeChanged="Window_SizeChanged" 
         Closing="Window_Closing" Icon="/POESKillTree;component/logo.ico" Loaded="Window_Loaded" WindowStartupLocation="CenterScreen"
@@ -18,6 +20,7 @@
         >
     <Window.Resources>
         <conv:AttributeToTextblockConverter x:Key="attributeToTextblockConverter" />
+        <converter:EnumToBoolConverter x:Key="EnumToBoolConverter" />
 
         <Style x:Key="ContainerStyleIsExpanded" TargetType="{x:Type GroupItem}">
             <Setter Property="Template">
@@ -298,6 +301,54 @@
                     <MenuItem.Icon>
                         <ContentControl Template="{StaticResource CopyToClipboardIcon}" />
                     </MenuItem.Icon>
+                </MenuItem>
+                <Separator />
+                <MenuItem>
+                    <MenuItem.Header>
+                        <l:Catalog Message="Scion ascendancy" />
+                    </MenuItem.Header>
+                    <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
+                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.None}}">
+                        <MenuItem.Header>
+                            <l:Catalog Message="None" />
+                        </MenuItem.Header>
+                    </MenuItem>
+                    <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
+                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Marauder}}">
+                        <MenuItem.Header>
+                            <l:Catalog Message="Marauder" />
+                        </MenuItem.Header>
+                    </MenuItem>
+                    <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
+                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Ranger}}">
+                        <MenuItem.Header>
+                            <l:Catalog Message="Ranger" />
+                        </MenuItem.Header>
+                    </MenuItem>
+                    <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
+                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Witch}}">
+                        <MenuItem.Header>
+                            <l:Catalog Message="Witch" />
+                        </MenuItem.Header>
+                    </MenuItem>
+                    <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
+                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Duelist}}">
+                        <MenuItem.Header>
+                            <l:Catalog Message="Duelist" />
+                        </MenuItem.Header>
+                    </MenuItem>
+                    <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
+                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Templar}}">
+                        <MenuItem.Header>
+                            <l:Catalog Message="Templar" />
+                        </MenuItem.Header>
+                    </MenuItem>
+                    <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
+                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Shadow}}">
+                        <MenuItem.Header>
+                            <l:Catalog Message="Shadow" />
+                        </MenuItem.Header>
+                    </MenuItem>
                 </MenuItem>
             </MenuItem>
             <MenuItem>

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -10,6 +10,7 @@
         xmlns:items="clr-namespace:POESKillTree.ViewModels.Items"
         xmlns:converter="clr-namespace:POESKillTree.Utils.Converter"
         xmlns:views="clr-namespace:POESKillTree.Views"
+        xmlns:ascendancy="clr-namespace:POESKillTree.Model.Ascendancy"
 
         mc:Ignorable="d" x:Class="POESKillTree.Views.MainWindow"
         Title="Path of Exile - Passive Skill Tree Planner" Height="667" Width="1200" SizeChanged="Window_SizeChanged" 
@@ -303,48 +304,48 @@
                     </MenuItem.Icon>
                 </MenuItem>
                 <Separator />
-                <MenuItem>
+                <MenuItem IsEnabled="{Binding IsScion, ElementName=window}">
                     <MenuItem.Header>
-                        <l:Catalog Message="Scion ascendancy" />
+                        <l:Catalog Message="Ascendant additional start" />
                     </MenuItem.Header>
                     <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
-                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.None}}">
+                              IsChecked="{Binding AscendantAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static ascendancy:AscendantAdditionalStart.None}}">
                         <MenuItem.Header>
                             <l:Catalog Message="None" />
                         </MenuItem.Header>
                     </MenuItem>
                     <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
-                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Marauder}}">
+                              IsChecked="{Binding AscendantAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static ascendancy:AscendantAdditionalStart.Marauder}}">
                         <MenuItem.Header>
                             <l:Catalog Message="Marauder" />
                         </MenuItem.Header>
                     </MenuItem>
                     <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
-                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Ranger}}">
+                              IsChecked="{Binding AscendantAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static ascendancy:AscendantAdditionalStart.Ranger}}">
                         <MenuItem.Header>
                             <l:Catalog Message="Ranger" />
                         </MenuItem.Header>
                     </MenuItem>
                     <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
-                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Witch}}">
+                              IsChecked="{Binding AscendantAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static ascendancy:AscendantAdditionalStart.Witch}}">
                         <MenuItem.Header>
                             <l:Catalog Message="Witch" />
                         </MenuItem.Header>
                     </MenuItem>
                     <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
-                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Duelist}}">
+                              IsChecked="{Binding AscendantAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static ascendancy:AscendantAdditionalStart.Duelist}}">
                         <MenuItem.Header>
                             <l:Catalog Message="Duelist" />
                         </MenuItem.Header>
                     </MenuItem>
                     <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
-                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Templar}}">
+                              IsChecked="{Binding AscendantAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static ascendancy:AscendantAdditionalStart.Templar}}">
                         <MenuItem.Header>
                             <l:Catalog Message="Templar" />
                         </MenuItem.Header>
                     </MenuItem>
                     <MenuItem local:MenuItemExtensions.GroupName="ScionAdditionalStart" IsCheckable="True"
-                              IsChecked="{Binding ScionAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static views:ScionAdditionalStart.Shadow}}">
+                              IsChecked="{Binding AscendantAdditionalStart, ElementName=window, Converter={StaticResource EnumToBoolConverter}, ConverterParameter={x:Static ascendancy:AscendantAdditionalStart.Shadow}}">
                         <MenuItem.Header>
                             <l:Catalog Message="Shadow" />
                         </MenuItem.Header>

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -49,6 +49,17 @@ using Path = System.IO.Path;
 
 namespace POESKillTree.Views
 {
+    public enum ScionAdditionalStart
+    {
+        None,
+        Marauder,
+        Ranger,
+        Witch,
+        Duelist,
+        Templar,
+        Shadow
+    }
+
     /// <summary>
     ///     Interaction logic for MainWindow.xaml
     /// </summary>
@@ -153,6 +164,33 @@ namespace POESKillTree.Views
                 {
                     PropertyChanged(this, new PropertyChangedEventArgs("NoAsyncTaskRunning"));
                 }
+            }
+        }
+
+        private ScionAdditionalStart _scionAdditionalStart = ScionAdditionalStart.None;
+
+        public ScionAdditionalStart ScionAdditionalStart
+        {
+            get { return _scionAdditionalStart; }
+            set
+            {
+                if (_scionAdditionalStart != ScionAdditionalStart.None)
+                {
+                    var start = SkillTree.rootNodeClassDictionary[SkillTree.CharName[(int) _scionAdditionalStart]];
+                    var scionStartNode = SkillTree.Skillnodes[(ushort) SkillTree.rootNodeClassDictionary[CharacterNames.Scion]];
+                    var oldConnections = SkillTree.Skillnodes[(ushort) start].Neighbor;
+                    oldConnections.ForEach(n => scionStartNode.Neighbor.Remove(n));
+                    oldConnections.ForEach(n => n.Neighbor.Remove(scionStartNode));
+                }
+                if (_tree.Chartype == 0 && value != ScionAdditionalStart.None)
+                {
+                    var start = SkillTree.rootNodeClassDictionary[SkillTree.CharName[(int)value]];
+                    var scionStartNode = SkillTree.Skillnodes[(ushort)SkillTree.rootNodeClassDictionary[CharacterNames.Scion]];
+                    var newConnections = SkillTree.Skillnodes[(ushort) start].Neighbor;
+                    scionStartNode.Neighbor.AddRange(newConnections);
+                    newConnections.ForEach(n => n.Neighbor.Add(scionStartNode));
+                }
+                _scionAdditionalStart = value;
             }
         }
 

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -166,8 +166,6 @@ namespace POESKillTree.Views
             get { return _ascendantAdditionalStart; }
             set
             {
-                // todo Warn if there are unconnected nodes after subclass or class change
-                // todo (maybe) show connection to start node
                 if (_ascendantAdditionalStart == value) return;
 
                 if (_ascendantAdditionalStart != AscendantAdditionalStart.None)
@@ -176,7 +174,7 @@ namespace POESKillTree.Views
                 }
                 if (value != AscendantAdditionalStart.None)
                 {
-                    Tree.ConnectWithStartNodesOf((int) value);
+                    Tree.ConnectScionWithStartNodesOf((int) value);
                 }
 
                 _ascendantAdditionalStart = value;

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -284,6 +284,7 @@
     <Compile Include="TreeGenerator\Views\SettingsWindow.xaml.cs">
       <DependentUpon>SettingsWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Model\Ascendancy\AscendantAdditionalStart.cs" />
     <Compile Include="Views\CraftWindow.xaml.cs">
       <DependentUpon>CraftWindow.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
As discussed in #219. Should be easily adjustable for actual ascendancy class support.

Nodes now have an additional field for connections that should be visible. For Ascendant starts the start nodes of the class are added as invisible connections to the Scion root node.

Some remaining issues:
- After switching the additional class start or the class (to non Scion) there might be unconnected nodes. Refunding any node refundes all unconnected ones, so this isn't a big issue.
- No connections are shown to the additional class faces since the root node is not skilled. This could be solved by skilling the root node (if that isn't necessary anyway, see below). However, I don't know how compatible two root nodes are with the URL format (in case it is not necessary) and this would need to be subtracted anywhere the total node count is used.
- Depending on how the stuff is actually implementing in the official skill tree planner, the additional root node might need to be added.

So I guess it's best to wait with merging this until we have the official data. Wouldn't be of any use before that anyway.