### PR TITLE
Fix for #251

### DIFF
--- a/WPFSKillTree/TreeGenerator/Algorithm/DistanceLookup.cs
+++ b/WPFSKillTree/TreeGenerator/Algorithm/DistanceLookup.cs
@@ -178,11 +178,19 @@ namespace POESKillTree.TreeGenerator.Algorithm
             _distancesFast = new int[_cacheSize, _cacheSize];
             _pathsFast = new ushort[_cacheSize, _cacheSize][];
 
-            FullyCached = true;
-            foreach (var node in nodes)
+
+            try
             {
-                Dijkstra(node);
+                foreach (var node in nodes)
+                {
+                    Dijkstra(node);
+                }
             }
+            catch (GraphNotConnectedException)
+            {
+                throw new InvalidOperationException("The graph is disconnected.");
+            }
+            FullyCached = true;
 
             // No longer needed.
             _distances = null;
@@ -289,6 +297,13 @@ namespace POESKillTree.TreeGenerator.Algorithm
             // Target node was not found because start and target are not connected.
             if (target != null)
                 throw new GraphNotConnectedException();
+
+            // Check if all nodes were reached
+            foreach (var otherNode in _nodes)
+            {
+                if (_pathsFast[start.DistancesIndex, otherNode.DistancesIndex] == null)
+                    throw new GraphNotConnectedException();
+            }
         }
 
         /// <summary>

--- a/WPFSKillTree/TreeGenerator/Solver/AbstractSolver.cs
+++ b/WPFSKillTree/TreeGenerator/Solver/AbstractSolver.cs
@@ -369,7 +369,9 @@ namespace POESKillTree.TreeGenerator.Solver
                             // Only add nodes in the subsettree if one is given.
                             || Settings.SubsetTree.Count > 0 && !Settings.SubsetTree.Contains(node.Id)
                             // Mastery nodes are obviously not useful.
-                            || node.IsMastery)
+                            || node.IsMastery
+                            // Ignore ascendancies for now
+                            || node.ascendancyName != null)
                             continue;
 
                         if (IncludeNodeInSearchGraph(node))


### PR DESCRIPTION
Fixing #251.

The algorithm now ignores all Ascendancy nodes as potential pathing nodes.
This also makes sense, because players can *really* just skill the Ascendancy nodes themselves.

It would make sense to disable the tagging of Ascendancy nodes altogether, but I don't want to make that decision myself.