### PR TITLE
Solver fixes

### DIFF
--- a/WPFSKillTree/Data/PseudoAttributes/Crit.xml
+++ b/WPFSKillTree/Data/PseudoAttributes/Crit.xml
@@ -34,9 +34,9 @@
 			<Conditions><WeaponClass>Staff</WeaponClass></Conditions>
 		</Attribute>
 	</PseudoAttribute>
-	<PseudoAttribute Name="#% increased Critical Strike Multiplier" Group="Critical Strike">
-		<Attribute Name="#% increased Critical Strike Multiplier" />
-		<Attribute Name="#% increased Critical Strike Multiplier with {0}">
+	<PseudoAttribute Name="+#% to Critical Strike Multiplier" Group="Critical Strike">
+		<Attribute Name="+#% to Critical Strike Multiplier" />
+		<Attribute Name="+#% to Critical Strike Multiplier with {0}">
 			<Conditions>
 				<AndComposition>
 					<WeaponClass>{0}</WeaponClass>
@@ -45,16 +45,16 @@
 				<Tag>{0}</Tag>
 			</Conditions>
 		</Attribute>
-		<Attribute Name="#% increased Critical Strike Multiplier while Dual Wielding">
+		<Attribute Name="+#% to Critical Strike Multiplier while Dual Wielding">
 			<Conditions><OffHand>Dual Wield</OffHand></Conditions>
 		</Attribute>
-		<Attribute Name="#% increased Critical Strike Multiplier for Spells">
+		<Attribute Name="+#% to Critical Strike Multiplier for Spells">
 			<Conditions><Tag>Spell</Tag></Conditions>
 		</Attribute>
-		<Attribute Name="#% increased Melee Critical Strike Multiplier">
+		<Attribute Name="+#% to Melee Critical Strike Multiplier">
 			<Conditions><Tag>Melee</Tag></Conditions>
 		</Attribute>
-		<Attribute Name="#% increased Global Critical Strike Multiplier while wielding a Staff">
+		<Attribute Name="+#% to Global Critical Strike Multiplier while wielding a Staff">
 			<Conditions><WeaponClass>Staff</WeaponClass></Conditions>
 		</Attribute>
 	</PseudoAttribute>

--- a/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
+++ b/WPFSKillTree/SkillTreeFiles/NodeHighlighter.cs
@@ -18,6 +18,16 @@ namespace POESKillTree.SkillTreeFiles
 
         public Dictionary<SkillNode, HighlightState> nodeHighlights = new Dictionary<SkillNode, HighlightState>();
 
+        /// <summary>
+        /// Returns flags without HighlightState.Tags if the node is an ascendancy node.
+        /// Returns flags unchanged if it is not.
+        /// </summary>
+        private static HighlightState CleanFlags(SkillNode node, HighlightState flags)
+        {
+            if (node.ascendancyName == null) return flags;
+            return flags & ~HighlightState.Tags;
+        }
+
         public bool NodeHasHighlights(SkillNode node, HighlightState flags)
         {
             if (nodeHighlights.ContainsKey(node))
@@ -27,23 +37,13 @@ namespace POESKillTree.SkillTreeFiles
             return false;
         }
 
-        public void ToggleHighlightNode(SkillNode node, HighlightState toggleFlags)
-        {
-            if (toggleFlags == 0) return;
-            if (nodeHighlights.ContainsKey(node))
-            {
-                nodeHighlights[node] ^= toggleFlags;
-                if (nodeHighlights[node] == 0) nodeHighlights.Remove(node);
-            }
-            else nodeHighlights.Add(node, toggleFlags);
-        }
-
         public void HighlightNode(SkillNode node, HighlightState newFlags)
         {
-            if (newFlags == 0) return;
+            var flags = CleanFlags(node, newFlags);
+            if (flags == 0) return;
             if (nodeHighlights.ContainsKey(node))
-                nodeHighlights[node] |= newFlags;
-            else nodeHighlights.Add(node, newFlags);
+                nodeHighlights[node] |= flags;
+            else nodeHighlights.Add(node, flags);
         }
 
         public void UnhighlightNode(SkillNode node, HighlightState removeFlags)
@@ -88,7 +88,7 @@ namespace POESKillTree.SkillTreeFiles
             foreach (var pair in pairs)
             {
                 nodeHighlights[pair.Key] &= ifFlags;
-                nodeHighlights[pair.Key] |= newFlags;
+                nodeHighlights[pair.Key] |= CleanFlags(pair.Key, newFlags);
             }
         }
     }

--- a/WPFSKillTree/TreeGenerator/Algorithm/DistanceLookup.cs
+++ b/WPFSKillTree/TreeGenerator/Algorithm/DistanceLookup.cs
@@ -178,11 +178,19 @@ namespace POESKillTree.TreeGenerator.Algorithm
             _distancesFast = new int[_cacheSize, _cacheSize];
             _pathsFast = new ushort[_cacheSize, _cacheSize][];
 
-            FullyCached = true;
-            foreach (var node in nodes)
+
+            try
             {
-                Dijkstra(node);
+                foreach (var node in nodes)
+                {
+                    Dijkstra(node);
+                }
             }
+            catch (GraphNotConnectedException)
+            {
+                throw new InvalidOperationException("The graph is disconnected.");
+            }
+            FullyCached = true;
 
             // No longer needed.
             _distances = null;
@@ -289,6 +297,13 @@ namespace POESKillTree.TreeGenerator.Algorithm
             // Target node was not found because start and target are not connected.
             if (target != null)
                 throw new GraphNotConnectedException();
+
+            // Check if all nodes were reached
+            foreach (var otherNode in _nodes)
+            {
+                if (_pathsFast[start.DistancesIndex, otherNode.DistancesIndex] == null)
+                    throw new GraphNotConnectedException();
+            }
         }
 
         /// <summary>

--- a/WPFSKillTree/TreeGenerator/Algorithm/DistanceLookup.cs
+++ b/WPFSKillTree/TreeGenerator/Algorithm/DistanceLookup.cs
@@ -177,20 +177,12 @@ namespace POESKillTree.TreeGenerator.Algorithm
             }
             _distancesFast = new int[_cacheSize, _cacheSize];
             _pathsFast = new ushort[_cacheSize, _cacheSize][];
-
-
-            try
-            {
-                foreach (var node in nodes)
-                {
-                    Dijkstra(node);
-                }
-            }
-            catch (GraphNotConnectedException)
-            {
-                throw new InvalidOperationException("The graph is disconnected.");
-            }
+            
             FullyCached = true;
+            foreach (var node in nodes)
+            {
+                Dijkstra(node);
+            }
 
             // No longer needed.
             _distances = null;
@@ -297,13 +289,6 @@ namespace POESKillTree.TreeGenerator.Algorithm
             // Target node was not found because start and target are not connected.
             if (target != null)
                 throw new GraphNotConnectedException();
-
-            // Check if all nodes were reached
-            foreach (var otherNode in _nodes)
-            {
-                if (_pathsFast[start.DistancesIndex, otherNode.DistancesIndex] == null)
-                    throw new GraphNotConnectedException();
-            }
         }
 
         /// <summary>

--- a/WPFSKillTree/TreeGenerator/Solver/AbstractSolver.cs
+++ b/WPFSKillTree/TreeGenerator/Solver/AbstractSolver.cs
@@ -369,7 +369,9 @@ namespace POESKillTree.TreeGenerator.Solver
                             // Only add nodes in the subsettree if one is given.
                             || Settings.SubsetTree.Count > 0 && !Settings.SubsetTree.Contains(node.Id)
                             // Mastery nodes are obviously not useful.
-                            || node.IsMastery)
+                            || node.IsMastery
+                            // Ignore ascendancies for now
+                            || node.ascendancyName != null)
                             continue;
 
                         if (IncludeNodeInSearchGraph(node))

--- a/WPFSKillTree/TreeGenerator/ViewModels/AdvancedTabViewModel.cs
+++ b/WPFSKillTree/TreeGenerator/ViewModels/AdvancedTabViewModel.cs
@@ -96,7 +96,7 @@ namespace POESKillTree.TreeGenerator.ViewModels
             {L10n.Message("Minion"), 12},
             {L10n.Message("Trap"), 13},
             {L10n.Message("Totem"), 14},
-            {"Everything else", 15}
+            {"Everything Else", 15}
         };
 
         /// <summary>


### PR DESCRIPTION
In addition to what was done by @MLanghof in #266:

- Disabled check- and cross-tagging of ascendancy nodes.
- Fixed Skill Tree Generator crashing on window opening.
- Renamed crit multi pseudo attributes to the new naming scheme.

Bugs I know of but don't have time to fix atm (probably won't get to them over the next few days):
- Ascendant additional start nodes are not used for the solver (even if the "Path of the ..." node is skilled). This is because the connections between the start nodes and the Ascendant nodes are not bidirectional so the start nodes are thrown out of the search space because they don't have the "Path of the ..." node as a neighbor.
- Ascendancy nodes count to the node limit in the Solvers.