### PR TITLE
Solver fixes

### DIFF
--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -770,9 +770,10 @@ namespace POESKillTree.SkillTreeFiles
 
             //SkilledNodes.Remove(nodeId);
 
+            var charStart = GetCharNodeId();
             var front = new HashSet<ushort>();
-            front.Add(SkilledNodes.First());
-            foreach (SkillNode i in Skillnodes[SkilledNodes.First()].Neighbor)
+            front.Add(charStart);
+            foreach (SkillNode i in Skillnodes[charStart].Neighbor)
                 if (SkilledNodes.Contains(i.Id))
                     front.Add(i.Id);
             var skilled_reachable = new HashSet<ushort>(front);
@@ -801,9 +802,10 @@ namespace POESKillTree.SkillTreeFiles
 
             SkilledNodes.Remove(nodeId);
 
+            var charStart = GetCharNodeId();
             var front = new HashSet<ushort>();
-            front.Add(SkilledNodes.First());
-            foreach (SkillNode i in Skillnodes[SkilledNodes.First()].Neighbor)
+            front.Add(charStart);
+            foreach (SkillNode i in Skillnodes[charStart].Neighbor)
                 if (SkilledNodes.Contains(i.Id))
                     front.Add(i.Id);
 

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -878,7 +878,7 @@ namespace POESKillTree.SkillTreeFiles
                         continue;
                     if (Skillnodes[newNode].IsMastery)
                         continue;
-                    if (Skillnodes[newNode].attributes.Any(s => AscendantClassStartRegex.IsMatch(s)))
+                    if (IsAscendantClassStartNode(newNode))
                         continue;
                     distance.Add(connection, dis + 1);
                     newOnes.Enqueue(connection);
@@ -905,6 +905,22 @@ namespace POESKillTree.SkillTreeFiles
             }
             result.Reverse();
             return result;
+        }
+
+        /// <summary>
+        /// Returns true iff node is a Ascendant "Path of the ..." node.
+        /// </summary>
+        private static bool IsAscendantClassStartNode(ushort node)
+        {
+            return IsAscendantClassStartNode(Skillnodes[node]);
+        }
+
+        /// <summary>
+        /// Returns true iff node is a Ascendant "Path of the ..." node.
+        /// </summary>
+        public static bool IsAscendantClassStartNode(SkillNode node)
+        {
+            return node.attributes.Any(s => AscendantClassStartRegex.IsMatch(s));
         }
 
         /// <summary>

--- a/WPFSKillTree/TreeGenerator/Solver/AbstractSolver.cs
+++ b/WPFSKillTree/TreeGenerator/Solver/AbstractSolver.cs
@@ -257,6 +257,18 @@ namespace POESKillTree.TreeGenerator.Solver
         /// </summary>
         private void BuildSearchGraph()
         {
+            // Make all directed edges from Scion Ascendant "Path of the ..." node undirected.
+            // This is really dirty but the whole code is so dependant on the skill tree stuff that
+            // I don't see a non dirty way.
+            var ascendantClassStartNodes = SkillTree.Skillnodes.Values.Where(SkillTree.IsAscendantClassStartNode).ToList();
+            foreach (var classStartNode in ascendantClassStartNodes)
+            {
+                foreach (var neighbor in classStartNode.Neighbor)
+                {
+                    neighbor.Neighbor.Add(classStartNode);
+                }
+            }
+
             _searchGraph = new SearchGraph();
             CreateStartNodes();
             CreateTargetNodes();
@@ -265,6 +277,15 @@ namespace POESKillTree.TreeGenerator.Solver
             _fixedNodes.UnionWith(_targetNodes.Select(node => node.Id));
             OnStartAndTargetNodesCreated();
             CreateSearchGraph();
+
+            // Remove all added edges again.
+            foreach (var classStartNode in ascendantClassStartNodes)
+            {
+                foreach (var neighbor in classStartNode.Neighbor)
+                {
+                    neighbor.Neighbor.Remove(classStartNode);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- Fix for #283. The first node added into SkilledNodes was used as character start node for refunding. The correct node is now used.
- Fixed solver not seeing the connection from Scion Ascendant "Path of the ..." nodes. This fix is not pretty. But with the whole code being as interconnected as it is, I don't think there is a pretty solution.