### PR TITLE
Summation of tree changes

### DIFF
--- a/WPFSKillTree/Model/Options.cs
+++ b/WPFSKillTree/Model/Options.cs
@@ -12,6 +12,7 @@ namespace POESKillTree.Model
         private bool _characterSheetBarOpened;
         private bool _buildsBarOpened;
         private bool _treeComparisonEnabled;
+        private bool _changeSummaryEnabled;
         private bool _showAllAscendancyClasses = true;
         private string _nodeSearchHighlightColor = "Red";
         private string _nodeAttrHighlightColor = "LawnGreen";
@@ -60,6 +61,12 @@ namespace POESKillTree.Model
         {
             get { return _treeComparisonEnabled; }
             set { SetProperty(ref _treeComparisonEnabled, value); }
+        }
+
+        public bool ChangeSummaryEnabled
+        {
+            get { return _changeSummaryEnabled; }
+            set { SetProperty(ref _changeSummaryEnabled, value); }
         }
 
         public bool ShowAllAscendancyClasses

--- a/WPFSKillTree/SkillTreeFiles/SkillTree.cs
+++ b/WPFSKillTree/SkillTreeFiles/SkillTree.cs
@@ -630,7 +630,7 @@ namespace POESKillTree.SkillTreeFiles
         public static Dictionary<string, List<float>> GetAttributesWithoutImplicit(IEnumerable<SkillNode> skilledNodes, int chartype, BanditSettings banditSettings)
         {
             var temp = new Dictionary<string, List<float>>();
-
+            
             foreach (var attr in CharBaseAttributes[chartype].Union(BaseAttributes).Union(banditSettings.Rewards))
             {
                 if (!temp.ContainsKey(attr.Key))
@@ -638,6 +638,32 @@ namespace POESKillTree.SkillTreeFiles
                 else if (temp[attr.Key].Any())
                     temp[attr.Key][0] += attr.Value;
             }
+            
+            foreach (var node in skilledNodes)
+            {
+                foreach (var attr in ExpandHybridAttributes(node.Attributes))
+                {
+                    if (!temp.ContainsKey(attr.Key))
+                        temp[attr.Key] = new List<float>();
+                    for (int i = 0; i < attr.Value.Count; i++)
+                    {
+                        if (temp.ContainsKey(attr.Key) && temp[attr.Key].Count > i)
+                            temp[attr.Key][i] += attr.Value[i];
+                        else
+                        {
+                            temp[attr.Key].Add(attr.Value[i]);
+                        }
+                    }
+                }
+            }
+
+            return temp;
+        }
+
+
+        public static Dictionary<string, List<float>> GetAttributesWithoutImplicitNodesOnly(IEnumerable<SkillNode> skilledNodes)
+        {
+            var temp = new Dictionary<string, List<float>>();
 
             foreach (var node in skilledNodes)
             {
@@ -659,6 +685,7 @@ namespace POESKillTree.SkillTreeFiles
 
             return temp;
         }
+
 
         /// <summary>
         /// Returns a task that finishes with a SkillTree object once it has been initialized.

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -414,6 +414,17 @@
                         <iconPacks:PackIconModern Kind="SectionCollapseAll" HorizontalAlignment="Center" />
                     </MenuItem.Icon>
                 </MenuItem>
+                <Separator />
+                <MenuItem x:Name="mnuShowSummary" IsCheckable="true"
+                          IsChecked="{Binding PersistentData.Options.ChangeSummaryEnabled,ElementName=window, Mode=TwoWay}"
+                          InputGestureText="Ctrl+G">
+                    <MenuItem.Header>
+                        <l:Catalog Message="Show summary of changes" />
+                    </MenuItem.Header>
+                    <MenuItem.ToolTip>
+                        <l:Catalog>Shows a summary of the total changes to the passive tree when hovering over a node.</l:Catalog>
+                    </MenuItem.ToolTip>
+                </MenuItem>
             </MenuItem>
             <MenuItem>
                 <MenuItem.Header>
@@ -491,17 +502,6 @@
                     <MenuItem.ToolTip>
                         <l:Catalog>Runs the 'Advanced' generator with the current settings set in the Skill Tree
                             Generator window.</l:Catalog>
-                    </MenuItem.ToolTip>
-                </MenuItem>
-                <Separator />
-                <MenuItem x:Name="mnuShowSummary" IsCheckable="true"
-                          IsChecked="{Binding PersistentData.Options.ChangeSummaryEnabled,ElementName=window, Mode=TwoWay}"
-                          InputGestureText="Ctrl+F">
-                    <MenuItem.Header>
-                        <l:Catalog Message="Show summary of changes" />
-                    </MenuItem.Header>
-                    <MenuItem.ToolTip>
-                        <l:Catalog>Shows a summary of the total changes to the passive tree when hovering over a node.</l:Catalog>
                     </MenuItem.ToolTip>
                 </MenuItem>
                 <Separator />

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -494,6 +494,17 @@
                     </MenuItem.ToolTip>
                 </MenuItem>
                 <Separator />
+                <MenuItem x:Name="mnuShowSummary" IsCheckable="true"
+                          IsChecked="{Binding PersistentData.Options.ChangeSummaryEnabled,ElementName=window, Mode=TwoWay}"
+                          InputGestureText="Ctrl+F">
+                    <MenuItem.Header>
+                        <l:Catalog Message="Show summary of changes" />
+                    </MenuItem.Header>
+                    <MenuItem.ToolTip>
+                        <l:Catalog>Shows a summary of the total changes to the passive tree when hovering over a node.</l:Catalog>
+                    </MenuItem.ToolTip>
+                </MenuItem>
+                <Separator />
                 <MenuItem Click="Menu_UntagAllNodes">
                     <MenuItem.Header>
                         <l:Catalog Message="Un_tag All Nodes" />

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -1533,6 +1533,45 @@ namespace POESKillTree.Views
                         sp.Children.Add(new TextBlock { Text = "Points to skill node: " + points });
                     }
 
+                    //Sum up the total change to attributes and add it to the tooltip
+                    if (_prePath != null | _toRemove != null)
+                    {
+
+
+                        var attributechanges = new Dictionary<string, List<float>>();
+
+                        int changedNodes;
+
+                        if (_prePath != null)
+                        {
+                            attributechanges = SkillTree.GetAttributesWithoutImplicitNodesOnly(_prePath);
+                            tooltip = "Total gain:";
+                            changedNodes = _prePath.Count();
+                        } else
+                        {
+                            attributechanges = SkillTree.GetAttributesWithoutImplicitNodesOnly(_toRemove);
+                            tooltip = "Total loss:";
+                            changedNodes = _toRemove.Count();
+                        }
+
+                        if (changedNodes > 1)
+                        {
+                            foreach (var attrchange in attributechanges)
+                            {
+                                if (attrchange.Value.Count != 0)
+                                {
+                                    var regex = new Regex(Regex.Escape("#"));
+                                    var attr = attrchange.Key;
+                                    foreach (var val in attrchange.Value)
+                                        attr = regex.Replace(attr, val.ToString(), 1);
+                                    tooltip += "\n" + attr;
+                                }
+                            }
+                            sp.Children.Add(new Separator());
+                            sp.Children.Add(new TextBlock { Text = tooltip });
+                        }
+                    }
+
                     _sToolTip.Content = sp;
                     if (!HighlightByHoverKeys.Any(Keyboard.IsKeyDown))
                     {

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -122,6 +122,8 @@ namespace POESKillTree.Views
         private bool _justLoaded;
         private string _lasttooltip;
 
+        private bool _showChangeSummary;
+
         private Vector2D _multransform;
 
         private List<SkillNode> _prePath;
@@ -646,6 +648,7 @@ namespace POESKillTree.Views
                     case Key.Y:
                         tbSkillURL_Redo();
                         break;
+                    /*
                     case Key.LeftCtrl:
                     case Key.RightCtrl:
                         if (_hoveredNode != null && !SkillTree.RootNodeList.Contains(_hoveredNode.Id))
@@ -653,7 +656,14 @@ namespace POESKillTree.Views
                             GenerateTooltipForNode(_hoveredNode, true);
                         }
                         break;
-
+                    */
+                    case Key.F:
+                        ToggleShowSummary();
+                        if (_hoveredNode != null && !SkillTree.RootNodeList.Contains(_hoveredNode.Id))
+                        {
+                            GenerateTooltipForNode(_hoveredNode, true);
+                        }
+                        break;
                 }
             }
 
@@ -679,6 +689,7 @@ namespace POESKillTree.Views
             {
                 HighlightNodesByHover();
             }
+            /*
             switch (e.Key)
             {
                 case Key.LeftCtrl:
@@ -689,6 +700,7 @@ namespace POESKillTree.Views
                     }
                     break;
             }
+            */
         }
 
         private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -1334,6 +1346,11 @@ namespace POESKillTree.Views
             PersistentData.Options.CharacterSheetBarOpened = !PersistentData.Options.CharacterSheetBarOpened;
         }
 
+        private void ToggleShowSummary()
+        {
+            PersistentData.Options.ChangeSummaryEnabled = !PersistentData.Options.ChangeSummaryEnabled;
+        }
+
         private void ToggleCharacterSheet(bool expanded)
         {
             PersistentData.Options.CharacterSheetBarOpened = expanded;
@@ -1545,7 +1562,7 @@ namespace POESKillTree.Views
                 }
 
                 //Change summary, activated with ctrl
-                if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+                if (PersistentData.Options.ChangeSummaryEnabled)
                 {
                     //Sum up the total change to attributes and add it to the tooltip
                     if (_prePath != null | _toRemove != null)

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -657,7 +657,7 @@ namespace POESKillTree.Views
                         }
                         break;
                     */
-                    case Key.F:
+                    case Key.G:
                         ToggleShowSummary();
                         if (_hoveredNode != null && !SkillTree.RootNodeList.Contains(_hoveredNode.Id))
                         {
@@ -1513,6 +1513,34 @@ namespace POESKillTree.Views
             _sToolTip.IsOpen = false;
         }
 
+        private void zbSkillTreeBackground_MouseMove(object sender, MouseEventArgs e)
+        {
+            var p = e.GetPosition(zbSkillTreeBackground.Child);
+            var v = new Vector2D(p.X, p.Y);
+            v = v * _multransform + _addtransform;
+
+            var node = Tree.FindNodeInRange(v, 50);
+            _hoveredNode = node;
+            if (node != null && !SkillTree.RootNodeList.Contains(node.Id))
+            {
+                GenerateTooltipForNode(node);
+            }
+            else if ((Tree.AscButtonPosition - v).Length < 150)
+            {
+                Tree.DrawAscendancyButton("Highlight");
+            }
+            else
+            {
+                _sToolTip.Tag = false;
+                _sToolTip.IsOpen = false;
+                _prePath = null;
+                _toRemove = null;
+                Tree?.ClearPath();
+                Tree?.ClearJewelHighlight();
+                Tree?.DrawAscendancyButton();
+            }
+        }
+
         private void GenerateTooltipForNode(SkillNode node, bool forcerefresh = false)
         {
             if (!Tree.DrawAscendancy && node.ascendancyName != null && !forcerefresh)
@@ -1610,34 +1638,6 @@ namespace POESKillTree.Views
                     _sToolTip.IsOpen = true;
                 }
                 _lasttooltip = tooltip;
-            }
-        }
-
-        private void zbSkillTreeBackground_MouseMove(object sender, MouseEventArgs e)
-        {
-            var p = e.GetPosition(zbSkillTreeBackground.Child);
-            var v = new Vector2D(p.X, p.Y);
-            v = v * _multransform + _addtransform;
-
-            var node = Tree.FindNodeInRange(v, 50);
-            _hoveredNode = node;
-            if (node != null && !SkillTree.RootNodeList.Contains(node.Id))
-            {
-                GenerateTooltipForNode(node);
-            }
-            else if ((Tree.AscButtonPosition - v).Length < 150)
-            {
-                Tree.DrawAscendancyButton("Highlight");
-            }
-            else
-            {
-                _sToolTip.Tag = false;
-                _sToolTip.IsOpen = false;
-                _prePath = null;
-                _toRemove = null;
-                Tree?.ClearPath();
-                Tree?.ClearJewelHighlight();
-                Tree?.DrawAscendancyButton();
             }
         }
 

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -648,15 +648,6 @@ namespace POESKillTree.Views
                     case Key.Y:
                         tbSkillURL_Redo();
                         break;
-                    /*
-                    case Key.LeftCtrl:
-                    case Key.RightCtrl:
-                        if (_hoveredNode != null && !SkillTree.RootNodeList.Contains(_hoveredNode.Id))
-                        {
-                            GenerateTooltipForNode(_hoveredNode, true);
-                        }
-                        break;
-                    */
                     case Key.G:
                         ToggleShowSummary();
                         if (_hoveredNode != null && !SkillTree.RootNodeList.Contains(_hoveredNode.Id))
@@ -689,18 +680,6 @@ namespace POESKillTree.Views
             {
                 HighlightNodesByHover();
             }
-            /*
-            switch (e.Key)
-            {
-                case Key.LeftCtrl:
-                case Key.RightCtrl:
-                    if (_hoveredNode != null && !SkillTree.RootNodeList.Contains(_hoveredNode.Id))
-                    {
-                        GenerateTooltipForNode(_hoveredNode, true);
-                    }
-                    break;
-            }
-            */
         }
 
         private void Window_SizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
I've added a summation of all the changes to attributes, to the tooltip that appears on hovering over a node, when clicking that node would change multiple nodes in the tree (adding or removing).

It's a bit clunky, but I think it would be a nice feature to have, as you can quickly compare clusters of nodes.

It also doesn't have any form of localization support atm, but so does the tooltip line directly above.