### PR TITLE
Add possibility to load tree as new build

### DIFF
--- a/WPFSKillTree/Controls/CommandCollectionViewModel.cs
+++ b/WPFSKillTree/Controls/CommandCollectionViewModel.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using POESKillTree.Common.ViewModels;
+using POESKillTree.Utils;
+
+namespace POESKillTree.Controls
+{
+    /// <summary>
+    /// Contains a collection of pairs of a title and a command. Can be used e.g. to make commands selectable
+    /// in a drop-down menu and execute them afterwards.
+    /// </summary>
+    public class CommandCollectionViewModel : Notifier
+    {
+        public class Item : Notifier
+        {
+            private string _title;
+            private ICommand _command;
+
+            public string Title
+            {
+                get { return _title; }
+                set { SetProperty(ref _title, value); }
+            }
+
+            public ICommand Command
+            {
+                get { return _command; }
+                set { SetProperty(ref _command, value); }
+            }
+
+            public Item(string title, ICommand command)
+            {
+                _title = title;
+                _command = command;
+            }
+        }
+
+
+        private Item _selectedItem;
+
+        public Item SelectedItem
+        {
+            get { return _selectedItem; }
+            set { SetProperty(ref _selectedItem, value); }
+        }
+
+        public ObservableCollection<Item> Items { get; } = new ObservableCollection<Item>();
+
+        private void Add(Item item)
+        {
+            Items.Add(item);
+            if (SelectedItem == null)
+            {
+                SelectedItem = item;
+            }
+        }
+
+        public void Add(string title, ICommand command)
+        {
+            Add(new Item(title, command));
+        }
+
+        public void Add(string title, Action action, Func<bool> canExeucte)
+        {
+            Add(new Item(title, new RelayCommand(action, canExeucte)));
+        }
+    }
+}

--- a/WPFSKillTree/Model/Options.cs
+++ b/WPFSKillTree/Model/Options.cs
@@ -19,6 +19,7 @@ namespace POESKillTree.Model
         private bool _downloadMissingItemImages;
         private ResetPreferences _resetPreferences = ResetPreferences.MainTree | ResetPreferences.AscendancyTree;
         private string _buildSavePath;
+        private int _loadBuildButtonIndex;
 
         public string Language
         {
@@ -102,6 +103,12 @@ namespace POESKillTree.Model
         {
             get { return _buildSavePath; }
             set { SetProperty(ref _buildSavePath, value); }
+        }
+
+        public int LoadTreeButtonIndex
+        {
+            get { return _loadBuildButtonIndex; }
+            set { SetProperty(ref _loadBuildButtonIndex, value); }
         }
     }
 }

--- a/WPFSKillTree/ViewModels/Builds/BuildValidator.cs
+++ b/WPFSKillTree/ViewModels/Builds/BuildValidator.cs
@@ -159,7 +159,7 @@ namespace POESKillTree.ViewModels.Builds
 
         private static bool IsNameValid(string name, string fullPath, out string errorMessage)
         {
-            if (string.IsNullOrEmpty(name))
+            if (string.IsNullOrWhiteSpace(name))
             {
                 errorMessage = L10n.Message("Value is required.");
                 return false;

--- a/WPFSKillTree/ViewModels/BuildsControlViewModel.cs
+++ b/WPFSKillTree/ViewModels/BuildsControlViewModel.cs
@@ -364,7 +364,7 @@ namespace POESKillTree.ViewModels
             await SaveBuildToFile(newFolder);
         }
 
-        private async Task NewBuild(IBuildFolderViewModel folder)
+        public async Task NewBuild(IBuildFolderViewModel folder)
         {
             var name = await _dialogCoordinator.ShowValidatingInputDialogAsync(this,
                 L10n.Message("New Build"),

--- a/WPFSKillTree/ViewModels/CommandCollectionViewModel.cs
+++ b/WPFSKillTree/ViewModels/CommandCollectionViewModel.cs
@@ -4,7 +4,7 @@ using System.Windows.Input;
 using POESKillTree.Common.ViewModels;
 using POESKillTree.Utils;
 
-namespace POESKillTree.Controls
+namespace POESKillTree.ViewModels
 {
     /// <summary>
     /// Contains a collection of pairs of a title and a command. Can be used e.g. to make commands selectable
@@ -45,25 +45,22 @@ namespace POESKillTree.Controls
             set { SetProperty(ref _selectedItem, value); }
         }
 
-        public ObservableCollection<Item> Items { get; } = new ObservableCollection<Item>();
-
-        private void Add(Item item)
+        public int SelectedIndex
         {
-            Items.Add(item);
-            if (SelectedItem == null)
-            {
-                SelectedItem = item;
-            }
+            get { return SelectedItem == null ? 0 : Items.IndexOf(SelectedItem); }
+            set { SelectedItem = Items.Count > value ? Items[value] : null; }
         }
+
+        public ObservableCollection<Item> Items { get; } = new ObservableCollection<Item>();
 
         public void Add(string title, ICommand command)
         {
-            Add(new Item(title, command));
+            Items.Add(new Item(title, command));
         }
 
         public void Add(string title, Action action, Func<bool> canExeucte)
         {
-            Add(new Item(title, new RelayCommand(action, canExeucte)));
+            Items.Add(new Item(title, new RelayCommand(action, canExeucte)));
         }
     }
 }

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -857,7 +857,7 @@
 
             <TextBox Grid.Column="3" Height="24" Margin="1,0,2.854,2" VerticalAlignment="Bottom"
                      Text="{Binding InputTreeUrl, UpdateSourceTrigger=PropertyChanged}"
-                     VerticalContentAlignment="Center" TextChanged="tbSkillURL_TextChanged" KeyUp="tbSkillURL_KeyUp"
+                     VerticalContentAlignment="Center" TextChanged="tbSkillURL_TextChanged"
                      controls:TextBoxHelper.SelectAllOnFocus="True">
                 <TextBox.ToolTip>
                     <l:Catalog Message="Skill tree link"/>
@@ -865,11 +865,18 @@
                 <controls:TextBoxHelper.Watermark>
                     <l:Catalog Message="Skill tree link"/>
                 </controls:TextBoxHelper.Watermark>
+                <TextBox.InputBindings>
+                    <KeyBinding Key="Enter"
+                                Command="{Binding LoadTreeButtonViewModel.SelectedItem.Command}" />
+                </TextBox.InputBindings>
             </TextBox>
 
-            <Button Grid.Column="4" Height="24" HorizontalAlignment="Right" x:Name="btnLoadBuild" IsEnabled="{Binding NoAsyncTaskRunning, ElementName=window}" VerticalAlignment="Bottom" MinWidth="75" Click="btnLoadBuild_Click" Margin="0,0,2,2">
-                <l:Catalog Message="Load Tree"/>
-            </Button>
+            <controls:SplitButton Grid.Column="4" Height="24" HorizontalAlignment="Right" VerticalAlignment="Bottom" MinWidth="75" Margin="0,0,2,2"
+                                  DataContext="{Binding LoadTreeButtonViewModel}"
+                                  Command="{Binding SelectedItem.Command}"
+                                  ItemsSource="{Binding Items}"
+                                  SelectedItem="{Binding SelectedItem}"
+                                  DisplayMemberPath="Title"/>
         </Grid>
     </Grid>
 </controls:MetroWindow>

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -871,7 +871,7 @@
                 </TextBox.InputBindings>
             </TextBox>
 
-            <controls:SplitButton Grid.Column="4" Height="24" HorizontalAlignment="Right" VerticalAlignment="Bottom" MinWidth="75" Margin="0,0,2,2"
+            <controls:SplitButton Grid.Column="4" Height="24" HorizontalAlignment="Center" VerticalAlignment="Bottom" MinWidth="110" Margin="0,0,2,2"
                                   DataContext="{Binding LoadTreeButtonViewModel}"
                                   Command="{Binding SelectedItem.Command}"
                                   ItemsSource="{Binding Items}"

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -564,6 +564,16 @@ namespace POESKillTree.Views
                 await BuildsControlViewModel.NewBuild(BuildsControlViewModel.BuildRoot);
                 await LoadBuildFromUrlAsync(url);
             }, () => NoAsyncTaskRunning);
+            LoadTreeButtonViewModel.SelectedIndex = PersistentData.Options.LoadTreeButtonIndex;
+            LoadTreeButtonViewModel.PropertyChanged += (o, args) =>
+            {
+                switch (args.PropertyName)
+                {
+                    case nameof(LoadTreeButtonViewModel.SelectedItem):
+                        PersistentData.Options.LoadTreeButtonIndex = LoadTreeButtonViewModel.SelectedIndex;
+                        break;
+                }
+            };
 
             await controller.CloseAsync();
         }

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -118,6 +118,8 @@ namespace POESKillTree.Views
             }
         }
 
+        public CommandCollectionViewModel LoadTreeButtonViewModel { get; } = new CommandCollectionViewModel();
+
         private Vector2D _addtransform;
         private bool _justLoaded;
         private string _lasttooltip;
@@ -547,6 +549,21 @@ namespace POESKillTree.Views
                 UpdateUI();
                 SetCurrentBuildUrlFromTree();
             };
+
+            LoadTreeButtonViewModel.Add(L10n.Message("Load Tree"), async () =>
+            {
+                if (InputTreeUrl == null)
+                    return;
+                await LoadBuildFromUrlAsync(InputTreeUrl);
+            }, () => NoAsyncTaskRunning);
+            LoadTreeButtonViewModel.Add(L10n.Message("Load as new build"), async () =>
+            {
+                if (InputTreeUrl == null)
+                    return;
+                var url = InputTreeUrl;
+                await BuildsControlViewModel.NewBuild(BuildsControlViewModel.BuildRoot);
+                await LoadBuildFromUrlAsync(url);
+            }, () => NoAsyncTaskRunning);
 
             await controller.CloseAsync();
         }
@@ -1793,14 +1810,6 @@ namespace POESKillTree.Views
             SearchUpdate();
         }
 
-        private async void tbSkillURL_KeyUp(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Enter && NoAsyncTaskRunning)
-            {
-                await LoadBuildFromUrlAsync(InputTreeUrl);
-            }
-        }
-
         private void tbSkillURL_TextChanged(object sender, TextChangedEventArgs e)
         {
             _undoList.Push(PersistentData.CurrentBuild.TreeUrl);
@@ -1845,11 +1854,6 @@ namespace POESKillTree.Views
                 PersistentData.CurrentBuild.TreeUrl = _redoList.Pop();
                 UpdateUI();
             }
-        }
-
-        private async void btnLoadBuild_Click(object sender, RoutedEventArgs e)
-        {
-            await LoadBuildFromUrlAsync(InputTreeUrl);
         }
 
         private async void btnPoeUrl_Click(object sender, RoutedEventArgs e)

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -200,6 +200,7 @@
     <Compile Include="Controls\ColorPickerButton.xaml.cs">
       <DependentUpon>ColorPickerButton.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\CommandCollectionViewModel.cs" />
     <Compile Include="Controls\Dialogs\BaseDialog.cs" />
     <Compile Include="Controls\Dialogs\DialogCoordinator.cs" />
     <Compile Include="Controls\Dialogs\DialogParticipation.cs" />

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -200,7 +200,7 @@
     <Compile Include="Controls\ColorPickerButton.xaml.cs">
       <DependentUpon>ColorPickerButton.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Controls\CommandCollectionViewModel.cs" />
+    <Compile Include="ViewModels\CommandCollectionViewModel.cs" />
     <Compile Include="Controls\Dialogs\BaseDialog.cs" />
     <Compile Include="Controls\Dialogs\DialogCoordinator.cs" />
     <Compile Include="Controls\Dialogs\DialogParticipation.cs" />


### PR DESCRIPTION
"Load Tree" button is a Split Button. Trees can either be loaded like they are now or as a new build.

Doing this as a PR to get opinions on the button functionality. I tried executing the commands when the button option is changed, but that let to 3 build creation popups per selection change and I think requiring the button to be clicked isn't much worse.