### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#PoESkillTree    
+# PoESkillTree    
 A Passive Skill Tree Planner for Path of Exile
 
 ![](https://cloud.githubusercontent.com/assets/381657/5123351/e9985f18-70aa-11e4-9cc7-250bade5f481.png)
-###Features
+### Features
 ---
 * URL Improvements
   * PoEBuilder, PoEURL and TinyURL parsing
@@ -18,9 +18,9 @@ A Passive Skill Tree Planner for Path of Exile
 * Tree comparison: Compare current tree with a saved one
 * Performance improvements
 
-###Install/Update
+### Install/Update
 ---
-####Install
+#### Install
 1. Go to the [release page](https://github.com/EmmittJ/PoESkillTree/releases) and select the version you would like, most likely the latest.
 2. Download
   1. Portal: choose the zip file
@@ -28,7 +28,7 @@ A Passive Skill Tree Planner for Path of Exile
 3. Unzip/Install it to a location of your choice
 4. Start POESKillTree.exe
 
-####Update
+#### Update
 
 |Automatic (2.1.1 and above)|
 ---
@@ -43,7 +43,7 @@ If you have settings and/or saved builds you want to keep when updating do this:
 
 If you are using a version that still uses the savedBuilds file, just copy that over to the new version and the program will migrate all saves to PersistentData.xml, after this the savedBuilds file is no longer needed.
 
-####Skilltree version
+#### Skilltree version
 The program always ships with the latest skilltree data available when the release is done. If you know there is a new version of the tree on the official website but no new version of this program is available you can do this:
 
 1. Delete the Data folder and then just start the program, it will download the latest version.
@@ -51,7 +51,7 @@ The program always ships with the latest skilltree data available when the relea
 
 Note: Both these options require that you can access the official Path of Exile website.
 
-###Hotkeys
+### Hotkeys
 ---
 * Shift + Left Click: Zoom In
 * Ctrl + Left Click: Zoom Out
@@ -74,13 +74,13 @@ Note: Both these options require that you can access the official Path of Exile 
 * Right Click: (Attributes) Highlight corresponding nodes in tree
 * Ctrl + S: Save build as
 
-###Help/Issues
+### Help/Issues
 ---
 * For help please check out the thread in the official forum: https://www.pathofexile.com/forum/view-thread/996805/
 * If you find any bugs/faults please report it here on GitHub
 * Miss any features? Create an issue here or post in the forum thread
 
-###Credits
+### Credits
 ---
 * Headhorr - for his original "Unofficial Offline Skilltree Calc" http://www.pathofexile.com/forum/view-thread/19723
 * Emmitt
@@ -93,6 +93,6 @@ Note: Both these options require that you can access the official Path of Exile 
 * MauranKilom
 * brather1ng
 
-###Screenshots
+### Screenshots
 ---
 ![](https://cloud.githubusercontent.com/assets/381657/5124182/64ca624a-70b4-11e4-9a8e-f63323c8dea3.png)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
