### PR TITLE
Fixed #468

### DIFF
--- a/WPFSKillTree/Controls/ZoomBorder.cs
+++ b/WPFSKillTree/Controls/ZoomBorder.cs
@@ -14,6 +14,14 @@ namespace POESKillTree.Controls
         private Point _start;
         private bool allowZoom = true;
 
+        const double ZOOM_STEP = 0.3;
+        
+        const double MAX_ZOOM = 75;
+        const double MIN_ZOOM = 0.5;
+
+        // Not sure if this takes the zoom factor into account, but this feels reasonable.
+        const double DRAG_THRESHOLD = 5;
+
         public Point Origin
         {
             get
@@ -134,8 +142,8 @@ namespace POESKillTree.Controls
                 TranslateTransform tt = GetTranslateTransform(_child);
                 ScaleTransform st = GetScaleTransform(_child);
 
-                const double zoom = .3;
-                if (st.ScaleX + zoom > 75 || st.ScaleY + zoom > 75)
+                const double zoom = ZOOM_STEP;
+                if (st.ScaleX + zoom > MAX_ZOOM || st.ScaleY + zoom > MAX_ZOOM)
                     return;
                 Point relative = e.GetPosition(_child);
 
@@ -159,8 +167,8 @@ namespace POESKillTree.Controls
                 TranslateTransform tt = GetTranslateTransform(_child);
                 ScaleTransform st = GetScaleTransform(_child);
 
-                const double zoom = -.3;
-                if (st.ScaleX + zoom < 0.5 || st.ScaleY + zoom < 0.5)
+                const double zoom = -ZOOM_STEP;
+                if (st.ScaleX + zoom < MIN_ZOOM || st.ScaleY + zoom < MIN_ZOOM)
                     return;
 
                 Point relative = e.GetPosition(_child);
@@ -200,15 +208,13 @@ namespace POESKillTree.Controls
 
         private void child_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            // Not sure if this takes the zoom factor into account, but this feels reasonable.
-            const double dragThreshold = 5;
             allowZoom = true;
             if (_child != null)
             {
                 _child.ReleaseMouseCapture();
                 Cursor = Cursors.Arrow;
 
-                if ((_start - e.GetPosition(this)).LengthSquared >= dragThreshold * dragThreshold)
+                if ((_start - e.GetPosition(this)).LengthSquared >= DRAG_THRESHOLD * DRAG_THRESHOLD)
                 {
                     // If we dragged a distance larger than our threshold, handle the up event so that
                     // it's not treated as a click on a skill node.
@@ -235,11 +241,7 @@ namespace POESKillTree.Controls
         {
             if (_child != null)
             {
-                var st = GetScaleTransform(_child);
-
-                var zoom = e.Delta > 0 ? .3 : -.3;
-
-                if (zoom > 0)
+                if (e.Delta > 0)
                     ZoomIn(e);
                 else
                     ZoomOut(e);

--- a/WPFSKillTree/Views/MainWindow.xaml
+++ b/WPFSKillTree/Views/MainWindow.xaml
@@ -606,7 +606,7 @@
 
         <TabControl Grid.Row="0" HorizontalAlignment="Right">
             <TabItem controls:ControlsHelper.HeaderFontSize="14"
-                     IsSelected="{Binding IsSelected, ElementName= tyPAssiveTree}">
+                     IsSelected="{Binding IsSelected, ElementName= tyPassiveTree}">
                 <TabItem.Header>
                     <l:Catalog Message="Skill Tree"/>
                 </TabItem.Header>
@@ -687,7 +687,7 @@
                         </Style.Setters>
                     </Style>
                 </TabControl.ItemContainerStyle>
-                <TabItem IsSelected="True" Name="tyPAssiveTree">
+                <TabItem IsSelected="True" Name="tyPassiveTree">
                     <local:ZoomBorder IsManipulationEnabled="True" x:Name="zbSkillTreeBackground" ClipToBounds="True" MouseMove="zbSkillTreeBackground_MouseMove" Click="zbSkillTreeBackground_Click" Background="Black" MouseLeave="zbSkillTreeBackground_MouseLeave" Margin="0,0,0,0" Focusable="True" PreviewMouseUp="zbSkillTreeBackground_PreviewMouseUp">
                         <Rectangle Height="500" Width="597" IsManipulationEnabled="True" x:Name="recSkillTree" Stretch="Fill"  ClipToBounds="True" Margin="0,0,0,0" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                     </local:ZoomBorder>

--- a/WPFSKillTree/Views/MainWindow.xaml.cs
+++ b/WPFSKillTree/Views/MainWindow.xaml.cs
@@ -739,6 +739,20 @@ namespace POESKillTree.Views
 
         private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
         {
+            if (SkillTree.SkillTreeRect.Height == 0) // Not yet initialized
+                return;
+            double aspectRatio = SkillTree.SkillTreeRect.Width / SkillTree.SkillTreeRect.Height;
+            if (zbSkillTreeBackground.ActualWidth / zbSkillTreeBackground.ActualHeight > aspectRatio)
+            {
+                recSkillTree.Height = zbSkillTreeBackground.ActualHeight;
+                recSkillTree.Width = aspectRatio * recSkillTree.Height;
+            }
+            else
+            {
+                recSkillTree.Width = zbSkillTreeBackground.ActualWidth;
+                recSkillTree.Height = recSkillTree.Width / aspectRatio;
+            }
+            //recSkillTree.UpdateLayout();
         }
 
         private bool? _canClose;


### PR DESCRIPTION
`recSkillTree` (the `Rectangle` that is filled by the actual skill tree drawing) is always size-clipped (but not necessarily [geometry-clipped](https://i.imgur.com/sWe2Mup.png)) to the `ZoomBorder` (or maybe `TabItem` or `Grid`) area, even with `ClipToBounds = false` (which seems to only control the latter clipping) on all parent elements. Since `ZoomBorder` translates and scales child contents, this size clipping means that part of the skill tree is clipped off if the original `Rectangle` (before transformations) is larger than this area.

I fixed this by adjusting the `recSkillTree` size on resize so that it always fits into the available area and is therefore never clipped. This changes the skill tree scaling behavior when resizing but I think this is unproblematic.