### PR TITLE
Fix build scripts with VS 2017; support C# 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Note: Both these options require that you can access the official Path of Exile 
 * If you find any bugs/faults please report it here on GitHub
 * Miss any features? Create an issue here or post in the forum thread
 
+## Information for contributors
+
+* The code requires Visual Studio 2017 to be compiled and run
+* It is compiled to .NET 2.5 using C# 7
+* To run the batch scripts in WPFSKillTree, your installation's Common7/Tools/ folder must be added to the PATH environment variable
+
 ## Credits
 
 * Headhorr - for his original "Unofficial Offline Skilltree Calc" http://www.pathofexile.com/forum/view-thread/19723

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -71,9 +71,8 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.XML" />
@@ -148,6 +147,7 @@
     <Folder Include="TestBuilds\gems\" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="TestBuilds\BuildUrls.xsd">
       <SubType>Designer</SubType>
@@ -185,7 +185,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UnitTests/app.config
+++ b/UnitTests/app.config
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="morelinq" version="2.4.1" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net45" />
 </packages>

--- a/UpdateDB/UpdateDB.csproj
+++ b/UpdateDB/UpdateDB.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -80,8 +80,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -122,7 +122,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/UpdateDB/packages.config
+++ b/UpdateDB/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="morelinq" version="2.4.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net45" />
 </packages>

--- a/WPFSKillTree/Model/Items/Mods/Mod.cs
+++ b/WPFSKillTree/Model/Items/Mods/Mod.cs
@@ -38,8 +38,7 @@ namespace POESKillTree.Model.Items.Mods
             {
                 foreach (var itemClass in jsonMasterMod.ItemClasses)
                 {
-                    ItemClass enumClass;
-                    if (ItemClassEx.TryParse(itemClass, out enumClass))
+                    if (ItemClassEx.TryParse(itemClass, out ItemClass enumClass))
                     {
                         _itemClasses.Add(enumClass);
                     }
@@ -48,8 +47,7 @@ namespace POESKillTree.Model.Items.Mods
             var spawnWeights = spawnWeightsReplacement ?? jsonMod.SpawnWeights;
             foreach (var spawnWeight in spawnWeights)
             {
-                Tags tag;
-                if (TagsEx.TryParse(spawnWeight.Tag, out tag))
+                if (TagsEx.TryParse(spawnWeight.Tag, out Tags tag))
                 {
                     _spawnTags.Add(Tuple.Create(tag, spawnWeight.CanSpawn));
                 }

--- a/WPFSKillTree/WPFSKillTree.csproj
+++ b/WPFSKillTree/WPFSKillTree.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -150,7 +150,6 @@
     </Reference>
     <Reference Include="MoreLinq, Version=2.4.20801.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\packages\morelinq.2.4.1\lib\net40\MoreLinq.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -166,9 +165,8 @@
       <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.7.0\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -1084,7 +1082,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/WPFSKillTree/app.config
+++ b/WPFSKillTree/app.config
@@ -1,14 +1,20 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
   </configSections>
   <runtime>
-    <loadFromRemoteSources enabled="true"/>
+    <loadFromRemoteSources enabled="true" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+    </assemblyBinding>
   </runtime>
   <system.net>
-    <defaultProxy useDefaultCredentials="true"/>
+    <defaultProxy useDefaultCredentials="true" />
   </system.net>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
 </configuration>

--- a/WPFSKillTree/build-locale.bat
+++ b/WPFSKillTree/build-locale.bat
@@ -4,7 +4,7 @@
 
 PUSHD %~dp0
 
-IF [%1] == [] cmd /C "vsvars32.bat && msbuild release.xml /target:BuildLocale"
-IF NOT [%1] == [] cmd /C "vsvars32.bat && msbuild release.xml /target:BuildAndCopyLocale /property:LocaleTargetDir=%1"
+IF [%1] == [] cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:BuildLocale"
+IF NOT [%1] == [] cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:BuildAndCopyLocale /property:LocaleTargetDir=%1"
 
 POPD

--- a/WPFSKillTree/dist-clean.bat
+++ b/WPFSKillTree/dist-clean.bat
@@ -1,8 +1,8 @@
 @ECHO OFF
 @REM Cleans up everything dist-release script created.
 
-@REM Check whether vsvars32 is found in PATH
-WHERE /Q vsvars32
+@REM Check whether vsdevcmd is found in PATH
+WHERE /Q vsdevcmd
 IF ERRORLEVEL% == 1 (
 	ECHO ERROR: Command vsdevcmd not found.
 	ECHO Please add Visual Studio's Common7\Tools directory to PATH environment variable.
@@ -10,6 +10,6 @@ IF ERRORLEVEL% == 1 (
 )
 
 @REM Run in separate process
-cmd /C "vsvars32.bat && msbuild release.xml /target:Clean"
+cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:Clean"
 
 :END

--- a/WPFSKillTree/dist-release.bat
+++ b/WPFSKillTree/dist-release.bat
@@ -12,8 +12,8 @@ IF ERRORLEVEL% == 1 (
 	GOTO :END
 )
 
-@REM Check whether vsvars32 is found in PATH
-WHERE /Q vsvars32
+@REM Check whether vsdevcmd is found in PATH
+WHERE /Q vsdevcmd
 IF ERRORLEVEL% == 1 (
 	ECHO ERROR: Command vsdevcmd not found.
 	ECHO Please add Visual Studio's Common7\Tools directory to PATH environment variable.
@@ -21,6 +21,6 @@ IF ERRORLEVEL% == 1 (
 )
 
 @REM Run in separate process
-cmd /C "vsvars32.bat && msbuild release.xml /target:Release"
+cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:Release"
 
 :END

--- a/WPFSKillTree/dist-update.bat
+++ b/WPFSKillTree/dist-update.bat
@@ -9,8 +9,8 @@ IF ERRORLEVEL% == 1 (
 	GOTO :END
 )
 
-@REM Check whether vsvars32 is found in PATH
-WHERE /Q vsvars32
+@REM Check whether vsdevcmd is found in PATH
+WHERE /Q vsdevcmd
 IF ERRORLEVEL% == 1 (
 	ECHO ERROR: Command vsdevcmd not found.
 	ECHO Please add Visual Studio's Common7\Tools directory to PATH environment variable.
@@ -18,6 +18,6 @@ IF ERRORLEVEL% == 1 (
 )
 
 @REM Run in separate process
-cmd /C "vsvars32.bat && msbuild release.xml /target:Update"
+cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:Update"
 
 :END

--- a/WPFSKillTree/dist-updateItemImages.bat
+++ b/WPFSKillTree/dist-updateItemImages.bat
@@ -9,8 +9,8 @@ IF ERRORLEVEL% == 1 (
 	GOTO :END
 )
 
-@REM Check whether vsvars32 is found in PATH
-WHERE /Q vsvars32
+@REM Check whether vsdevcmd is found in PATH
+WHERE /Q vsdevcmd
 IF ERRORLEVEL% == 1 (
 	ECHO ERROR: Command vsdevcmd not found.
 	ECHO Please add Visual Studio's Common7\Tools directory to PATH environment variable.
@@ -18,6 +18,6 @@ IF ERRORLEVEL% == 1 (
 )
 
 @REM Run in separate process
-cmd /C "vsvars32.bat && msbuild release.xml /target:UpdateItemImages"
+cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:UpdateItemImages"
 
 :END

--- a/WPFSKillTree/dist-updateVersion.bat
+++ b/WPFSKillTree/dist-updateVersion.bat
@@ -10,8 +10,8 @@ IF ERRORLEVEL% == 1 (
 	GOTO :END
 )
 
-@REM Check whether vsvars32 is found in PATH
-WHERE /Q vsvars32
+@REM Check whether vsdevcmd is found in PATH
+WHERE /Q vsdevcmd
 IF ERRORLEVEL% == 1 (
 	ECHO ERROR: Command vsdevcmd not found.
 	ECHO Please add Visual Studio's Common7\Tools directory to PATH environment variable.
@@ -19,7 +19,7 @@ IF ERRORLEVEL% == 1 (
 )
 
 @REM Run in separate process
-cmd /C "vsvars32.bat && msbuild release.xml /target:UpdateAssemblyInfo"
-cmd /C "vsvars32.bat && msbuild release.xml /target:Clean"
+cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:UpdateAssemblyInfo"
+cmd /C "vsdevcmd.bat && cd ""%~dp0"" && msbuild release.xml /target:Clean"
 
 :END

--- a/WPFSKillTree/packages.config
+++ b/WPFSKillTree/packages.config
@@ -8,11 +8,11 @@
   <package id="MahApps.Metro" version="1.3.0" targetFramework="net45" />
   <package id="MahApps.Metro.IconPacks.Modern" version="1.1.0" targetFramework="net45" />
   <package id="MahApps.Metro.SimpleChildWindow" version="1.3.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.WindowsAPICodePack-Core" version="1.1.0.0" targetFramework="net40-Client" />
   <package id="Microsoft.WindowsAPICodePack-Shell" version="1.1.0.0" targetFramework="net40-Client" />
   <package id="morelinq" version="2.4.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Fix build scripts to work with VS 2017
- Update Microsoft.Net.Compilers NuGet package to support C# 7
- Update System.ValueTuple NuGet package to C# 7 version
- Use C# 7 features in one file to test compiling
- Add "Information for contributors" readme section. If someone thinks I missed something, just add it.

@EmmittJ and @MLanghof: as this wasn't as simple as I initially thought (not just changing the .bat file called in build scripts), it would be good if you can verify that both compiling/running the program and running the scripts works (with no further required setup than what I added to the readme).

The target framework is still .NET 4.5 so this shouldn't affect runnability of the compiled program, but if anyone has an old Windows or a Linux setup, it would be great if that could be confirmed.

Close #476 